### PR TITLE
trying to get rid of workOS CORS error log (trivial) and fixed posthog env var

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -156,7 +156,7 @@ function ShareProjectCallout() {
         </Authenticated>
         <Unauthenticated>
             <Button size="sm" className="whitespace-nowrap" asChild>
-              <Link href="/sign-in">
+              <Link href="/sign-in" prefetch={false}>
                 Submit a project
               </Link>
             </Button>
@@ -242,7 +242,7 @@ function ProjectRow({
                   onClick={(e) => e.stopPropagation()}
                   className="flex h-11 w-12 flex-col items-center justify-center gap-0.5 rounded-xl border-zinc-200 px-2 py-2 text-xs font-semibold leading-tight hover:!bg-background hover:!text-foreground hover:ring-2 hover:ring-accent hover:ring-offset-2 transition-all"
                 >
-                  <Link href="/sign-in">
+                  <Link href="/sign-in" prefetch={false}>
                     <span aria-hidden="true" className="text-inherit">↑</span>
                     <span className="text-xs font-semibold text-inherit">{project.upvotes}</span>
                   </Link>

--- a/app/(app)/project/[id]/page.tsx
+++ b/app/(app)/project/[id]/page.tsx
@@ -265,7 +265,7 @@ export default function ProjectPage({
                     className="rounded-full border-zinc-200 px-4 py-2.5 text-sm font-semibold !text-foreground hover:!bg-background hover:!text-foreground hover:ring-2 hover:ring-accent hover:ring-offset-2 transition-all"
                     asChild
                   >
-                    <Link href="/sign-in">
+                    <Link href="/sign-in" prefetch={false}>
                     ↑ {project.upvotes}
                     </Link>
                   </Button>

--- a/components/CommentForm.tsx
+++ b/components/CommentForm.tsx
@@ -56,7 +56,7 @@ export function CommentForm({
           Sign in to join the discussion
         </p>
         <Button variant="outline" asChild>
-          <Link href="/sign-in">
+          <Link href="/sign-in" prefetch={false}>
             Sign In
           </Link>
         </Button>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -35,11 +35,11 @@ export function Header() {
         <div className="flex items-center gap-3">
           <Unauthenticated>
             <Button size="sm" asChild>
-              <Link href="/sign-in">
+              <Link href="/sign-in" prefetch={false}>
                 Sign In
               </Link>
             </Button>
-            <Link href="/sign-up">
+            <Link href="/sign-up" prefetch={false}>
               <Button size="sm">
                 Sign Up
               </Button>


### PR DESCRIPTION
Had to turn off prefetch of next Link component redirects to workOS /sign-in and /sign-up routes since prefetch messes up the CORS I think:

What was actually happening
Next.js Link with prefetch enabled was preloading /sign-in via an internal fetch request tied to RSC (?_rsc=...).​

That request hit your /sign-in route, which redirected to the WorkOS /user_management/authorize URL.

Because this whole chain started as a fetch (XHR), the browser treated the redirect to https://api.workos.com/.../authorize as a CORS request, and complained that the authorize endpoint has no Access-Control-Allow-Origin.​

When you actually click the link and the browser does a full navigation, the redirect to WorkOS is just a normal top-level redirect, so CORS does not apply and the flow works fine.​

So:

The CORS error you saw in the console was mostly a side effect of prefetch, not a true runtime failure for real user clicks.

It is still worth suppressing to avoid noise and potential edge issues by using:

tsx
<Link href="/sign-in" prefetch={false}>
  Sign In
</Link>