### PR TITLE
Add preview media to chat project cards

### DIFF
--- a/components/chat/ProjectCardsDisplay.tsx
+++ b/components/chat/ProjectCardsDisplay.tsx
@@ -3,7 +3,8 @@
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import Link from "next/link";
-import { ArrowUpRight } from "lucide-react";
+import Image from "next/image";
+import { ArrowUpRight, Play } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -39,35 +40,78 @@ export function ProjectCardsDisplay({
             {[...Array(Math.min(projectIds.length, 4))].map((_, i) => (
               <Card key={i} className="py-3">
                 <CardHeader className="px-3 py-0">
-                  <Skeleton className="h-4 w-3/4" />
-                  <Skeleton className="h-3 w-full mt-2" />
-                  <Skeleton className="h-3 w-2/3 mt-1" />
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <Skeleton className="h-4 w-3/4" />
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-3 w-2/3" />
+                    </div>
+                    <Skeleton className="h-16 w-24 rounded-md" />
+                  </div>
                 </CardHeader>
               </Card>
             ))}
           </>
         ) : projects.length > 0 ? (
-          projects.map((project) => (
-            <Link
-              key={project._id}
-              href={`/project/${project._id}`}
-              target="_blank"
-            >
-              <Card className="py-3 hover:bg-muted/50 transition-colors cursor-pointer h-full">
-                <CardHeader className="px-3 py-0">
-                  <CardTitle className="text-sm font-medium flex items-center gap-1">
-                    <span className="truncate">{project.name}</span>
-                    <ArrowUpRight className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
-                  </CardTitle>
-                  {project.summary && (
-                    <CardDescription className="text-xs line-clamp-2">
-                      {project.summary}
-                    </CardDescription>
-                  )}
-                </CardHeader>
-              </Card>
-            </Link>
-          ))
+          projects.map((project) => {
+            const firstMedia = project.previewMedia?.[0];
+            const thumbnailUrl = firstMedia?.url;
+            const isVideo = firstMedia?.type === "video";
+
+            return (
+              <Link
+                key={project._id}
+                href={`/project/${project._id}`}
+                target="_blank"
+              >
+                <Card className="py-3 hover:bg-muted/50 transition-colors cursor-pointer h-full">
+                  <CardHeader className="px-3 py-0">
+                    <div className="flex items-start gap-3">
+                      <div className="flex-1 min-w-0">
+                        <CardTitle className="text-sm font-medium flex items-center gap-1">
+                          <span className="truncate">{project.name}</span>
+                          <ArrowUpRight className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
+                        </CardTitle>
+                        {project.summary && (
+                          <CardDescription className="text-xs line-clamp-2">
+                            {project.summary}
+                          </CardDescription>
+                        )}
+                      </div>
+
+                      {thumbnailUrl && (
+                        <div className="flex-shrink-0 relative w-24 h-16 self-start group overflow-hidden rounded-md bg-muted border border-border/60">
+                          {isVideo ? (
+                            <video
+                              src={thumbnailUrl}
+                              className="h-full w-full object-cover"
+                              muted
+                              playsInline
+                            />
+                          ) : (
+                            <Image
+                              src={thumbnailUrl}
+                              alt={project.name}
+                              fill
+                              sizes="96px"
+                              className="object-cover"
+                            />
+                          )}
+                          {isVideo && (
+                            <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/10 transition-colors">
+                              <div className="rounded-full bg-black/50 p-1.5 backdrop-blur-sm">
+                                <Play className="h-3 w-3 fill-white text-white" />
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </CardHeader>
+                </Card>
+              </Link>
+            );
+          })
         ) : (
           <p className="text-sm text-muted-foreground col-span-2">
             No projects found.

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -1568,20 +1568,40 @@ export const getProjectsByEntryIdsPublic = query({
   handler: async (ctx, args) => {
     const projects = await Promise.all(
       args.entryIds.map(async (entryId) => {
-        return await ctx.db
+        const project = await ctx.db
           .query("projects")
           .withIndex("by_entryId", (q) => q.eq("entryId", entryId))
           .filter((q) => q.eq(q.field("status"), "active"))
           .first();
+
+        if (!project) {
+          return null;
+        }
+
+        const mediaFiles = await ctx.db
+          .query("mediaFiles")
+          .withIndex("by_project_ordered", (q) => q.eq("projectId", project._id))
+          .order("asc")
+          .take(1);
+
+        const previewMedia = await Promise.all(
+          mediaFiles.map(async (media) => ({
+            _id: media._id,
+            storageId: media.storageId,
+            type: media.type,
+            url: await ctx.storage.getUrl(media.storageId),
+          }))
+        );
+
+        return {
+          _id: project._id,
+          name: project.name,
+          summary: project.summary,
+          previewMedia,
+        };
       })
     );
 
-    return projects
-      .filter((p): p is NonNullable<typeof p> => p !== null)
-      .map((p) => ({
-        _id: p._id,
-        name: p.name,
-        summary: p.summary,
-      }));
+    return projects.filter((p): p is NonNullable<typeof p> => p !== null);
   },
 });


### PR DESCRIPTION
## Summary
- include preview media URLs in the public projects lookup for chat cards
- render chat project cards with image/video thumbnails and matching skeleton layout

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0d53dfb08321bf7073b35463e09b)