### PR TITLE
Add ownerId to focusAreas schema and set on create

### DIFF
--- a/convex/focusAreas.ts
+++ b/convex/focusAreas.ts
@@ -45,6 +45,7 @@ export const create = mutation({
       name: args.name,
       group: args.group,
       description: args.description,
+      ownerId: user._id,
       isActive: true,
       createdAt: Date.now(),
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -138,6 +138,7 @@ export default defineSchema({
     name: v.string(),
     group: v.optional(v.string()),
     description: v.optional(v.string()),
+    ownerId: v.optional(v.id("users")),
     isActive: v.boolean(),
     createdAt: v.number(),
   })


### PR DESCRIPTION
### Motivation
- Track ownership of focus areas by adding an `ownerId` field and persisting the creating user when a focus area is created.

### Description
- Add `ownerId` as `v.optional(v.id("users"))` to the `focusAreas` table in `convex/schema.ts` to remain backward compatible.
- Update the `create` mutation in `convex/focusAreas.ts` to include `ownerId: user._id` in the insert payload when creating a focus area.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b800e63d483219f1401a5fbd7af39)