### PR TITLE
Fix rich text content overflow in flex containers

### DIFF
--- a/app/(app)/project/[id]/page.tsx
+++ b/app/(app)/project/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function ProjectPage({
     <div className="min-h-screen bg-zinc-50">
       <main className="mx-auto max-w-5xl px-6 py-10">
         <div className="space-y-8 lg:flex lg:items-start lg:gap-10 lg:space-y-0">
-          <section className="flex-1 space-y-4">
+          <section className="flex-1 min-w-0 space-y-4">
             <div className="space-y-2">
               <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-zinc-500 sm:flex-nowrap">
                 <div className="flex items-center gap-2">

--- a/app/globals.css
+++ b/app/globals.css
@@ -167,6 +167,12 @@ body {
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: #52525b;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .rich-text-content h1 {


### PR DESCRIPTION
Add word-wrap properties and min-width: 0 to prevent text from extending beyond the viewport in flex layouts. The flex child section also needs min-w-0 to allow shrinking below content size.

https://claude.ai/code/session_01WSyCa6oYaRdzhmHviVZ5CY