### PR TITLE
Fix rich text content clipping by removing overflow: hidden

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -169,10 +169,8 @@ body {
   color: #52525b;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  word-break: break-word;
   max-width: 100%;
   min-width: 0;
-  overflow: hidden;
 }
 
 .rich-text-content h1 {


### PR DESCRIPTION
The overflow: hidden was cutting off text at line edges. Removed it
along with word-break: break-word (which breaks words mid-character).
overflow-wrap: break-word alone handles long words properly.

https://claude.ai/code/session_01WSyCa6oYaRdzhmHviVZ5CY