### PR TITLE
Disable modal behavior for emoji picker popover

### DIFF
--- a/components/CreateFocusAreaDialog.tsx
+++ b/components/CreateFocusAreaDialog.tsx
@@ -33,7 +33,7 @@ function EmojiPickerPopover({
   const [open, setOpen] = useState(false);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger asChild>
         <Button
           type="button"


### PR DESCRIPTION
## Summary
Updated the emoji picker popover in the CreateFocusAreaDialog component to prevent modal behavior, allowing users to interact with content behind the popover.

## Changes
- Added `modal={false}` prop to the `<Popover>` component in the EmojiPickerPopover function
- This allows the popover to float above the page without blocking interaction with underlying elements

## Details
The emoji picker popover now operates in non-modal mode, which is more appropriate for a utility popover that shouldn't trap focus or prevent users from interacting with other page elements while selecting an emoji.

https://claude.ai/code/session_01SogRKQEWFb8RtvXp1dHwWD