### PR TITLE
Add sidebar with member count to space page and reduce page top padding

### DIFF
--- a/app/(app)/create-team/page.tsx
+++ b/app/(app)/create-team/page.tsx
@@ -38,7 +38,7 @@ export default function CreateTeam() {
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
         <div className="mb-2">
           <h2 className="text-3xl font-semibold tracking-tight">Create a team</h2>
           <p className="mt-2 text-sm text-zinc-500">

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -97,7 +97,7 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-8 px-6 pb-16 pt-10">
+      <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-8 px-6 pb-16 pt-4">
         <section className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_400px]">
           <div className="space-y-2">
             <LayoutGroup>

--- a/app/(app)/profile/[id]/page.tsx
+++ b/app/(app)/profile/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function ProfilePage({
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto w-full max-w-5xl space-y-8 px-6 pb-16 pt-10">
+      <main className="mx-auto w-full max-w-5xl space-y-8 px-6 pb-16 pt-4">
         <div className="relative flex flex-col items-center gap-6 pr-12 text-center md:items-start md:text-left">
           {!isOwner && email && (
             <div className="absolute right-0 top-0 flex gap-1">

--- a/app/(app)/project/[id]/edit/page.tsx
+++ b/app/(app)/project/[id]/edit/page.tsx
@@ -207,7 +207,7 @@ export default function EditProject({ params }: { params: Promise<{ id: string }
   if (isLoading) {
     return (
       <div className="min-h-screen bg-zinc-50">
-        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
           <p className="text-zinc-500">Loading...</p>
         </main>
       </div>
@@ -217,7 +217,7 @@ export default function EditProject({ params }: { params: Promise<{ id: string }
   if (!project) {
     return (
       <div className="min-h-screen bg-zinc-50">
-        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
           <p className="text-zinc-500">Project not found</p>
         </main>
       </div>
@@ -226,7 +226,7 @@ export default function EditProject({ params }: { params: Promise<{ id: string }
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
         <div className="mb-2 space-y-2">
           <h2 className="text-3xl font-semibold tracking-tight">Update your project details</h2>
         </div>

--- a/app/(app)/space/[id]/page.tsx
+++ b/app/(app)/space/[id]/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { useCurrentUser } from "@/app/useCurrentUser";
 import { ProjectRow, type ProjectRowData } from "@/components/ProjectRow";
 import { SpaceIcon } from "@/components/SpaceIcon";
+import { Users } from "lucide-react";
 
 export default function SpacePage({
   params,
@@ -30,6 +31,7 @@ export default function SpacePage({
   );
   const { isAuthenticated, user } = useCurrentUser();
   const isFollowing = useQuery(api.focusAreas.isFollowingSpace, { focusAreaId });
+  const memberCount = useQuery(api.focusAreas.getMemberCount, { focusAreaId });
   const toggleFollowSpace = useMutation(api.focusAreas.toggleFollowSpace);
   const toggleUpvote = useMutation(api.projects.toggleUpvote);
   const toggleAdoption = useMutation(api.projects.toggleAdoption);
@@ -92,82 +94,101 @@ export default function SpacePage({
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-8 px-6 pb-16 pt-10">
-        <div className="space-y-2">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              {focusArea && <SpaceIcon icon={focusArea.icon} name={focusArea.name} size="md" />}
-              <h2 className="text-3xl font-semibold tracking-tight">
-                {focusArea?.name ?? "Loading..."}
-              </h2>
-            </div>
-            {isAuthenticated ? (
-              <Button
-                variant={isFollowing ? "default" : "outline"}
-                size="sm"
-                onClick={handleFollowSpace}
-              >
-                {isFollowing ? "Joined" : "Join"}
-              </Button>
-            ) : (
-              <Button variant="outline" size="sm" asChild>
-                <Link href="/sign-in" prefetch={false}>
-                  Join
-                </Link>
-              </Button>
-            )}
-          </div>
-          {focusArea?.description && (
-            <p className="text-sm text-zinc-500">{focusArea.description}</p>
-          )}
-        </div>
-
-        <LayoutGroup>
-          <div className="space-y-0">
-            {isLoading ? (
-              <div className="py-8 text-center text-sm text-zinc-500">
-                Loading projects...
+      <main className="mx-auto w-full max-w-[1400px] px-6 pb-16 pt-4">
+        <div className="space-y-8 lg:flex lg:items-start lg:gap-10 lg:space-y-0">
+          <section className="flex-1 min-w-0 space-y-8">
+            <div className="space-y-2">
+              <div className="flex items-center gap-3">
+                {focusArea && <SpaceIcon icon={focusArea.icon} name={focusArea.name} size="md" />}
+                <h2 className="text-3xl font-semibold tracking-tight">
+                  {focusArea?.name ?? "Loading..."}
+                </h2>
               </div>
-            ) : results.length ? (
-              <>
-                {results.map((project, index) => (
-                  <React.Fragment key={project._id}>
-                    {index > 0 && <Separator className="bg-zinc-200" />}
-                    <motion.div
-                      layout
-                      layoutId={project._id}
-                      transition={{
-                        type: "spring",
-                        stiffness: 500,
-                        damping: 35,
-                      }}
-                    >
-                      <ProjectRow
-                        project={project as ProjectRowData}
-                        onUpvote={handleUpvote}
-                        onAdopt={handleAdopt}
-                        currentUser={currentUser}
-                        isAuthenticated={isAuthenticated}
-                      />
-                    </motion.div>
-                  </React.Fragment>
-                ))}
-                <div ref={loadMoreRef} className="h-4" />
-                {isLoadingMore && (
-                  <div className="py-4 text-center text-sm text-zinc-500">
-                    Loading more projects...
+              {focusArea?.description && (
+                <p className="text-sm text-zinc-500">{focusArea.description}</p>
+              )}
+            </div>
+
+            <LayoutGroup>
+              <div className="space-y-0">
+                {isLoading ? (
+                  <div className="py-8 text-center text-sm text-zinc-500">
+                    Loading projects...
+                  </div>
+                ) : results.length ? (
+                  <>
+                    {results.map((project, index) => (
+                      <React.Fragment key={project._id}>
+                        {index > 0 && <Separator className="bg-zinc-200" />}
+                        <motion.div
+                          layout
+                          layoutId={project._id}
+                          transition={{
+                            type: "spring",
+                            stiffness: 500,
+                            damping: 35,
+                          }}
+                        >
+                          <ProjectRow
+                            project={project as ProjectRowData}
+                            onUpvote={handleUpvote}
+                            onAdopt={handleAdopt}
+                            currentUser={currentUser}
+                            isAuthenticated={isAuthenticated}
+                          />
+                        </motion.div>
+                      </React.Fragment>
+                    ))}
+                    <div ref={loadMoreRef} className="h-4" />
+                    {isLoadingMore && (
+                      <div className="py-4 text-center text-sm text-zinc-500">
+                        Loading more projects...
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="rounded-3xl bg-zinc-100/60 p-6 text-center text-sm text-zinc-500 space-y-3">
+                    <p className="font-medium text-zinc-900">
+                      No projects in this space yet.
+                    </p>
                   </div>
                 )}
-              </>
-            ) : (
-              <div className="rounded-3xl bg-zinc-100/60 p-6 text-center text-sm text-zinc-500 space-y-3">
-                <p className="font-medium text-zinc-900">
-                  No projects in this space yet.
-                </p>
               </div>
-            )}
-          </div>
-        </LayoutGroup>
+            </LayoutGroup>
+          </section>
+
+          <aside className="w-full lg:sticky lg:top-20 lg:w-72 xl:w-80">
+            <div className="rounded-lg bg-zinc-100 p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                    Members
+                  </p>
+                  <div className="mt-1 flex items-center gap-2 text-sm font-medium text-zinc-700">
+                    <Users className="h-4 w-4 text-zinc-400" />
+                    <span>{memberCount ?? 0}</span>
+                  </div>
+                </div>
+
+                {isAuthenticated ? (
+                  <Button
+                    variant={isFollowing ? "default" : "outline"}
+                    size="sm"
+                    onClick={handleFollowSpace}
+                  >
+                    {isFollowing ? "Joined" : "Join"}
+                  </Button>
+                ) : (
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/sign-in" prefetch={false}>
+                      Join
+                    </Link>
+                  </Button>
+                )}
+              </div>
+            </div>
+          </aside>
+        </div>
       </main>
     </div>
   );

--- a/app/(app)/submit/confirm/page.tsx
+++ b/app/(app)/submit/confirm/page.tsx
@@ -96,7 +96,7 @@ function ConfirmSubmissionContent() {
   if (!projectId) {
     return (
       <div className="min-h-screen bg-zinc-50">
-        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
           <p className="text-center text-zinc-500">Invalid project ID</p>
         </main>
       </div>
@@ -106,7 +106,7 @@ function ConfirmSubmissionContent() {
   if (!project) {
     return (
       <div className="min-h-screen bg-zinc-50">
-        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+        <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
           <p className="text-center text-zinc-500">Loading...</p>
         </main>
       </div>
@@ -115,7 +115,7 @@ function ConfirmSubmissionContent() {
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
         <div className="mb-2 space-y-2">
           <h2 className="text-3xl font-semibold tracking-tight">Share what you&apos;re working on</h2>
           <Accordion type="single" collapsible>
@@ -262,7 +262,7 @@ export default function ConfirmSubmission() {
     <Suspense
       fallback={
         <div className="min-h-screen bg-zinc-50">
-          <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+          <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
             <p className="text-center text-zinc-500">Loading...</p>
           </main>
         </div>

--- a/app/(app)/submit/page.tsx
+++ b/app/(app)/submit/page.tsx
@@ -184,7 +184,7 @@ export default function SubmitProject() {
 
   return (
     <div className="min-h-screen bg-zinc-50">
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-10">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 pb-16 pt-4">
         <div className="mb-2 space-y-2">
           <h2 className="text-3xl font-semibold tracking-tight">Share what you&apos;re working on</h2>
         </div>

--- a/convex/focusAreas.ts
+++ b/convex/focusAreas.ts
@@ -117,6 +117,17 @@ export const isFollowingSpace = query({
   },
 });
 
+export const getMemberCount = query({
+  args: { focusAreaId: v.id("focusAreas") },
+  handler: async (ctx, args) => {
+    const members = await ctx.db
+      .query("userFocusAreas")
+      .withIndex("by_focus_area", (q) => q.eq("focusAreaId", args.focusAreaId))
+      .collect();
+    return members.length;
+  },
+});
+
 export const toggleFollowSpace = mutation({
   args: { focusAreaId: v.id("focusAreas") },
   handler: async (ctx, args) => {


### PR DESCRIPTION
- Add getMemberCount query to convex/focusAreas.ts using existing by_focus_area index
- Restructure space page into two-column layout with sticky sidebar
- Sidebar displays member count and join/leave button (moved from header)
- Reduce top padding (pt-10 -> pt-4) across all pages to eliminate excessive gap below fixed header