### PR TITLE
Replace Textarea with RichTextEditor for thread body input

### DIFF
--- a/app/(app)/create-thread/page.tsx
+++ b/app/(app)/create-thread/page.tsx
@@ -8,7 +8,8 @@ import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { RichTextEditor } from "@/components/RichTextEditor";
+import { isRichTextEmpty } from "@/lib/utils";
 import { SpacePicker } from "@/components/SpacePicker";
 
 export default function CreateThreadPage() {
@@ -35,7 +36,7 @@ export default function CreateThreadPage() {
     try {
       const threadId = await createThread({
         title: title.trim(),
-        body: body.trim() || undefined,
+        body: isRichTextEmpty(body) ? undefined : body,
         focusAreaId,
       });
       router.push(`/thread/${threadId}`);
@@ -81,13 +82,10 @@ export default function CreateThreadPage() {
               Body{" "}
               <span className="text-zinc-400 font-normal">(optional)</span>
             </label>
-            <Textarea
+            <RichTextEditor
               value={body}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setBody(e.target.value)
-              }
+              onChange={setBody}
               placeholder="Add more context"
-              className="min-h-24"
               disabled={isSubmitting}
             />
           </div>

--- a/app/(app)/thread/[id]/page.tsx
+++ b/app/(app)/thread/[id]/page.tsx
@@ -13,11 +13,11 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { CommentForm } from "@/components/CommentForm";
 import { CommentThread } from "@/components/CommentThread";
 import { RichTextContent } from "@/components/RichTextContent";
+import { RichTextEditor } from "@/components/RichTextEditor";
 import Link from "next/link";
 import { ArrowBigUp, Forward, Pencil, Trash2 } from "lucide-react";
-import { getRelativeTime } from "@/lib/utils";
+import { getRelativeTime, isRichTextEmpty } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { SpaceIcon } from "@/components/SpaceIcon";
 import {
   Breadcrumb,
@@ -111,7 +111,7 @@ export default function ThreadPage({
       await updateThread({
         threadId,
         title: editTitle.trim(),
-        body: editBody.trim() || undefined,
+        body: isRichTextEmpty(editBody) ? undefined : editBody,
       });
       setIsEditing(false);
     } catch (error) {
@@ -254,11 +254,10 @@ export default function ThreadPage({
                     disabled={isSaving}
                     autoFocus
                   />
-                  <Textarea
+                  <RichTextEditor
                     value={editBody}
-                    onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setEditBody(e.target.value)}
+                    onChange={setEditBody}
                     placeholder="Add more context (optional)"
-                    className="min-h-16 text-sm"
                     disabled={isSaving}
                   />
                   <div className="flex items-center justify-between">

--- a/components/CreateThreadForm.tsx
+++ b/components/CreateThreadForm.tsx
@@ -7,7 +7,8 @@ import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { RichTextEditor } from "@/components/RichTextEditor";
+import { isRichTextEmpty } from "@/lib/utils";
 import { MessageSquarePlus } from "lucide-react";
 
 interface CreateThreadFormProps {
@@ -31,7 +32,7 @@ export function CreateThreadForm({ focusAreaId, defaultExpanded, onSuccess }: Cr
     try {
       await createThread({
         title: title.trim(),
-        body: body.trim() || undefined,
+        body: isRichTextEmpty(body) ? undefined : body,
         focusAreaId,
       });
       setTitle("");
@@ -71,11 +72,10 @@ export function CreateThreadForm({ focusAreaId, defaultExpanded, onSuccess }: Cr
         disabled={isSubmitting}
         autoFocus
       />
-      <Textarea
+      <RichTextEditor
         value={body}
-        onChange={(e) => setBody(e.target.value)}
+        onChange={setBody}
         placeholder="Add more context (optional)"
-        className="min-h-16 text-sm"
         disabled={isSubmitting}
       />
       <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
This PR replaces the plain text `Textarea` component with a new `RichTextEditor` component across all thread creation and editing interfaces. This enables users to format thread bodies with rich text capabilities while maintaining the same user experience.

## Key Changes
- **Component Replacement**: Replaced `Textarea` imports and usage with `RichTextEditor` in:
  - `app/(app)/create-thread/page.tsx`
  - `app/(app)/thread/[id]/page.tsx`
  - `components/CreateThreadForm.tsx`

- **Validation Logic**: Updated body validation to use new `isRichTextEmpty()` utility function instead of `trim()` checks, since rich text content requires different empty state detection

- **Event Handler Simplification**: Simplified `onChange` handlers from `(e) => setBody(e.target.value)` to direct `onChange={setBody}`, indicating the RichTextEditor component handles the value transformation internally

- **Removed Styling**: Removed component-specific className props (`min-h-24`, `min-h-16 text-sm`) that are now handled by the RichTextEditor component itself

## Implementation Details
- The `isRichTextEmpty()` utility function is imported from `@/lib/utils` and used consistently across all thread body submission points
- The RichTextEditor component abstracts away the complexity of rich text handling while maintaining a simple onChange interface
- All three locations (create page, thread edit, and form component) now use the same rich text editing experience

https://claude.ai/code/session_01B4sBwtdN1xhQjYCzC8RbL7