### PR TITLE
Add comment activity email notifications

### DIFF
--- a/convex/commentNotifications.ts
+++ b/convex/commentNotifications.ts
@@ -1,0 +1,65 @@
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { isEmailEnabled } from "./emails";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEDUP_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Enqueues a comment-activity email for the content owner.
+ * Called from both project and thread addComment mutations.
+ *
+ * Skips if:
+ * - The commenter is the content owner
+ * - The owner has projectActivity emails disabled
+ * - A comment_activity email was already enqueued for this user within the dedup window
+ */
+export async function enqueueCommentEmail(
+  ctx: MutationCtx,
+  args: {
+    contentType: "project" | "thread";
+    contentId: string;
+    contentTitle: string;
+    contentOwnerUserId: Id<"users">;
+    commenterUserId: Id<"users">;
+    commenterName: string;
+    commentSnippet: string;
+  }
+): Promise<void> {
+  if (args.commenterUserId === args.contentOwnerUserId) return;
+
+  const owner = await ctx.db.get(args.contentOwnerUserId);
+  if (!owner) return;
+  if (!isEmailEnabled(owner, "projectActivity")) return;
+
+  // Dedup: skip if a comment_activity email was recently enqueued for this user
+  const cutoff = Date.now() - DEDUP_WINDOW_MS;
+  const recentEmail = await ctx.db
+    .query("emailQueue")
+    .withIndex("by_userId_type_createdAt", (q) =>
+      q
+        .eq("userId", args.contentOwnerUserId)
+        .eq("type", "comment_activity")
+        .gte("createdAt", cutoff)
+    )
+    .first();
+
+  if (recentEmail) return;
+
+  await ctx.db.insert("emailQueue", {
+    userId: args.contentOwnerUserId,
+    type: "comment_activity",
+    status: "pending",
+    payload: {
+      contentType: args.contentType,
+      contentId: args.contentId,
+      contentTitle: args.contentTitle,
+      commenterName: args.commenterName,
+      commentSnippet: args.commentSnippet,
+    },
+    createdAt: Date.now(),
+  });
+}

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -2,6 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getCurrentUserOrThrow, getCurrentUser } from "./users";
 import { createProjectNotification } from "./notifications";
+import { enqueueCommentEmail } from "./commentNotifications";
 import { calculateHotScore } from "./projects";
 
 export const addComment = mutation({
@@ -40,6 +41,16 @@ export const addComment = mutation({
         projectId: project._id,
         type: "comment",
         commentId,
+      });
+
+      await enqueueCommentEmail(ctx, {
+        contentType: "project",
+        contentId: args.projectId,
+        contentTitle: project.name,
+        contentOwnerUserId: project.userId,
+        commenterUserId: user._id,
+        commenterName: user.name,
+        commentSnippet: args.content.slice(0, 200),
       });
     }
 

--- a/convex/emailRenderer.ts
+++ b/convex/emailRenderer.ts
@@ -55,6 +55,14 @@ export type SpaceActivityPayload = {
   creatorName: string;
 };
 
+export type CommentActivityPayload = {
+  contentType: "project" | "thread";
+  contentId: string;
+  contentTitle: string;
+  commenterName: string;
+  commentSnippet: string;
+};
+
 export type WeeklyDigestPayload = {
   ownProjectActivity: OwnProjectActivity[];
   ownProjectTotals: {
@@ -603,6 +611,110 @@ export function renderSpaceActivityEmail(args: {
     `View it here: ${contentUrl}`,
     "",
     `You're receiving this because you follow g/${payload.focusAreaName}. This is an automated email.`,
+    `Manage your email preferences: ${profileUrl}`,
+  ].join("\n");
+
+  return { subject, html, text };
+}
+
+// ─── Comment Activity Email ─────────────────────────────────────────────────
+
+export function renderCommentActivityEmail(args: {
+  recipientName: string;
+  payload: CommentActivityPayload;
+  baseUrl: string;
+  profileUrl: string;
+}): RenderedEmail {
+  const { recipientName, payload, baseUrl, profileUrl } = args;
+  const contentLabel = payload.contentType === "project" ? "project" : "thread";
+
+  const truncatedTitle =
+    payload.contentTitle.length > 60
+      ? `${payload.contentTitle.slice(0, 57)}...`
+      : payload.contentTitle;
+
+  const subject = `New comment on your ${contentLabel}: "${truncatedTitle}"`;
+
+  const contentPath =
+    payload.contentType === "project"
+      ? `/project/${payload.contentId}`
+      : `/thread/${payload.contentId}`;
+  const contentUrl = joinUrl(baseUrl, contentPath);
+  const preheader = `${escapeHtml(payload.commenterName)} commented on your ${contentLabel}`;
+
+  const truncatedSnippet =
+    payload.commentSnippet.length > 200
+      ? `${payload.commentSnippet.slice(0, 197)}...`
+      : payload.commentSnippet;
+
+  const html = `
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>${escapeHtml(subject)}</title>
+      </head>
+      <body style="margin: 0; padding: 0; background-color: #f4f4f5; color: #18181b; font-family: Arial, sans-serif;">
+        <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
+          ${preheader}
+        </div>
+        <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: collapse; background-color: #f4f4f5;">
+          <tr>
+            <td align="center" style="padding: 24px 12px;">
+              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="max-width: 640px; border-collapse: collapse; background-color: #ffffff; border-radius: 18px;">
+                <tr>
+                  <td style="padding: 28px 28px 24px; border-bottom: 1px solid #e4e4e7;">
+                    <div style="font-size: 28px; font-weight: 700; color: #166534; margin: 0 0 16px;">Garden</div>
+                    <div style="font-size: 14px; color: #71717a; margin: 0 0 6px;">New comment on your ${escapeHtml(contentLabel)}</div>
+                    <div style="font-size: 20px; font-weight: 700; color: #18181b; margin: 0 0 16px;">
+                      <a href="${escapeHtml(contentUrl)}" style="color: #18181b; text-decoration: none;">${escapeHtml(payload.contentTitle)}</a>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 24px 28px;">
+                    <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: collapse; border: 1px solid #d4d4d8; border-radius: 12px;">
+                      <tr>
+                        <td style="padding: 18px;">
+                          <div style="font-size: 14px; font-weight: 600; color: #18181b; margin: 0 0 8px;">
+                            ${escapeHtml(payload.commenterName)} commented:
+                          </div>
+                          <div style="font-size: 14px; line-height: 1.6; color: #52525b; margin: 0 0 16px;">
+                            "${escapeHtml(truncatedSnippet)}"
+                          </div>
+                          <a href="${escapeHtml(contentUrl)}" style="display: inline-block; background-color: #166534; color: #ffffff; text-decoration: none; font-size: 14px; font-weight: 700; padding: 10px 18px; border-radius: 999px;">View ${escapeHtml(contentLabel)}</a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 0 28px 28px; font-size: 12px; line-height: 1.6; color: #71717a;">
+                    You're receiving this because someone commented on your ${escapeHtml(contentLabel)}. This is an automated email.
+                    <a href="${escapeHtml(profileUrl)}" style="color: #71717a;">Manage your email preferences</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>
+  `.trim();
+
+  const text = [
+    `Garden — New comment on your ${contentLabel}`,
+    "",
+    `Hi ${recipientName},`,
+    "",
+    `${payload.commenterName} commented on your ${contentLabel} "${payload.contentTitle}":`,
+    "",
+    `"${truncatedSnippet}"`,
+    "",
+    `View it here: ${contentUrl}`,
+    "",
+    `You're receiving this because someone commented on your ${contentLabel}. This is an automated email.`,
     `Manage your email preferences: ${profileUrl}`,
   ].join("\n");
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -13,8 +13,10 @@ import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import {
   renderWeeklyDigestEmail,
   renderSpaceActivityEmail,
+  renderCommentActivityEmail,
   type WeeklyDigestPayload,
   type SpaceActivityPayload,
+  type CommentActivityPayload,
 } from "./emailRenderer";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -92,6 +94,16 @@ export const sendEmail = internalAction({
       const rendered = renderSpaceActivityEmail({
         recipientName: recipient.name,
         payload: args.payload as SpaceActivityPayload,
+        baseUrl,
+        profileUrl,
+      });
+      subject = rendered.subject;
+      html = rendered.html;
+      text = rendered.text;
+    } else if (args.type === "comment_activity") {
+      const rendered = renderCommentActivityEmail({
+        recipientName: recipient.name,
+        payload: args.payload as CommentActivityPayload,
         baseUrl,
         profileUrl,
       });

--- a/convex/threads.ts
+++ b/convex/threads.ts
@@ -4,6 +4,7 @@ import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { getCurrentUser, getCurrentUserOrThrow } from "./users";
 import { calculateHotScore } from "./projects/helpers";
+import { enqueueCommentEmail } from "./commentNotifications";
 
 // ─── Creation ────────────────────────────────────────────────────────────────
 
@@ -386,6 +387,18 @@ export const addComment = mutation({
         engagementScore: newEngagementScore,
         hotScore: calculateHotScore(newEngagementScore, thread.createdAt, now),
       });
+
+      if (thread.userId !== user._id) {
+        await enqueueCommentEmail(ctx, {
+          contentType: "thread",
+          contentId: args.threadId,
+          contentTitle: thread.title,
+          contentOwnerUserId: thread.userId,
+          commenterUserId: user._id,
+          commenterName: user.name,
+          commentSnippet: args.content.slice(0, 200),
+        });
+      }
     }
 
     return commentId;


### PR DESCRIPTION
## Summary
This PR adds email notifications when someone comments on a user's project or thread. The implementation includes a new email template, notification queueing logic, and integration with existing comment mutations.

## Key Changes
- **New email type**: Added `CommentActivityPayload` type and `renderCommentActivityEmail()` function to generate comment activity emails with HTML and plain text versions
- **Comment notification service**: Created `convex/commentNotifications.ts` with `enqueueCommentEmail()` helper that:
  - Skips notifications if the commenter is the content owner
  - Respects user email preferences (projectActivity setting)
  - Implements 30-minute deduplication window to avoid email spam
- **Integration with mutations**: Updated both `convex/comments.ts` (project comments) and `convex/threads.ts` (thread comments) to enqueue emails when comments are added
- **Email sending**: Extended `convex/emails.ts` to handle the new `comment_activity` email type

## Implementation Details
- Comment snippets are truncated to 200 characters in the email body
- Content titles are truncated to 60 characters in the subject line
- Deduplication uses a 30-minute window to batch multiple comments from different users
- Email is only sent if the content owner has `projectActivity` emails enabled
- Self-comments are explicitly skipped

https://claude.ai/code/session_01STiS6ByCqFV8hUKwrbcFQY