### PR TITLE
Add email notifications for comment replies

### DIFF
--- a/convex/commentNotifications.ts
+++ b/convex/commentNotifications.ts
@@ -63,3 +63,60 @@ export async function enqueueCommentEmail(
     createdAt: Date.now(),
   });
 }
+
+/**
+ * Enqueues a reply-activity email for the parent comment author.
+ * Called from addComment when parentCommentId is set.
+ *
+ * Skips if:
+ * - The replier is the parent comment author
+ * - The parent comment author has projectActivity emails disabled
+ * - A comment_activity email was already enqueued for this user within the dedup window
+ */
+export async function enqueueReplyEmail(
+  ctx: MutationCtx,
+  args: {
+    contentType: "project" | "thread";
+    contentId: string;
+    contentTitle: string;
+    parentCommentUserId: Id<"users">;
+    replierUserId: Id<"users">;
+    replierName: string;
+    commentSnippet: string;
+  }
+): Promise<void> {
+  if (args.replierUserId === args.parentCommentUserId) return;
+
+  const parentAuthor = await ctx.db.get(args.parentCommentUserId);
+  if (!parentAuthor) return;
+  if (!isEmailEnabled(parentAuthor, "projectActivity")) return;
+
+  // Dedup: skip if a comment_activity email was recently enqueued for this user
+  const cutoff = Date.now() - DEDUP_WINDOW_MS;
+  const recentEmail = await ctx.db
+    .query("emailQueue")
+    .withIndex("by_userId_type_createdAt", (q) =>
+      q
+        .eq("userId", args.parentCommentUserId)
+        .eq("type", "comment_activity")
+        .gte("createdAt", cutoff)
+    )
+    .first();
+
+  if (recentEmail) return;
+
+  await ctx.db.insert("emailQueue", {
+    userId: args.parentCommentUserId,
+    type: "comment_activity",
+    status: "pending",
+    payload: {
+      contentType: args.contentType,
+      contentId: args.contentId,
+      contentTitle: args.contentTitle,
+      commenterName: args.replierName,
+      commentSnippet: args.commentSnippet,
+      isReply: true,
+    },
+    createdAt: Date.now(),
+  });
+}

--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -2,7 +2,7 @@ import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import { getCurrentUserOrThrow, getCurrentUser } from "./users";
 import { createProjectNotification } from "./notifications";
-import { enqueueCommentEmail } from "./commentNotifications";
+import { enqueueCommentEmail, enqueueReplyEmail } from "./commentNotifications";
 import { calculateHotScore } from "./projects";
 
 export const addComment = mutation({
@@ -52,6 +52,27 @@ export const addComment = mutation({
         commenterName: user.name,
         commentSnippet: args.content.slice(0, 200),
       });
+    }
+
+    // Notify the parent comment author when someone replies to their comment
+    if (args.parentCommentId && project) {
+      const parentComment = await ctx.db.get(args.parentCommentId);
+      if (
+        parentComment &&
+        !parentComment.isDeleted &&
+        parentComment.userId !== user._id &&
+        parentComment.userId !== project.userId
+      ) {
+        await enqueueReplyEmail(ctx, {
+          contentType: "project",
+          contentId: args.projectId,
+          contentTitle: project.name,
+          parentCommentUserId: parentComment.userId,
+          replierUserId: user._id,
+          replierName: user.name,
+          commentSnippet: args.content.slice(0, 200),
+        });
+      }
     }
 
     return commentId;

--- a/convex/emailRenderer.ts
+++ b/convex/emailRenderer.ts
@@ -61,6 +61,7 @@ export type CommentActivityPayload = {
   contentTitle: string;
   commenterName: string;
   commentSnippet: string;
+  isReply?: boolean;
 };
 
 export type WeeklyDigestPayload = {
@@ -750,20 +751,25 @@ export function renderCommentActivityEmail(args: {
 }): RenderedEmail {
   const { recipientName, payload, baseUrl, profileUrl } = args;
   const contentLabel = payload.contentType === "project" ? "project" : "thread";
+  const isReply = payload.isReply === true;
 
   const truncatedTitle =
     payload.contentTitle.length > 60
       ? `${payload.contentTitle.slice(0, 57)}...`
       : payload.contentTitle;
 
-  const subject = `New comment on your ${contentLabel}: "${truncatedTitle}"`;
+  const subject = isReply
+    ? `New reply on ${contentLabel}: "${truncatedTitle}"`
+    : `New comment on your ${contentLabel}: "${truncatedTitle}"`;
 
   const contentPath =
     payload.contentType === "project"
       ? `/project/${payload.contentId}`
       : `/thread/${payload.contentId}`;
   const contentUrl = joinUrl(baseUrl, contentPath);
-  const preheader = `${escapeHtml(payload.commenterName)} commented on your ${contentLabel}`;
+  const preheader = isReply
+    ? `${escapeHtml(payload.commenterName)} replied to your comment`
+    : `${escapeHtml(payload.commenterName)} commented on your ${contentLabel}`;
 
   const truncatedSnippet =
     payload.commentSnippet.length > 200
@@ -789,7 +795,7 @@ export function renderCommentActivityEmail(args: {
                 <tr>
                   <td style="padding: 28px 28px 24px; border-bottom: 1px solid #e4e4e7;">
                     <div style="font-size: 28px; font-weight: 700; color: #166534; margin: 0 0 16px;">Garden</div>
-                    <div style="font-size: 14px; color: #71717a; margin: 0 0 6px;">New comment on your ${escapeHtml(contentLabel)}</div>
+                    <div style="font-size: 14px; color: #71717a; margin: 0 0 6px;">${isReply ? "New reply to your comment" : `New comment on your ${escapeHtml(contentLabel)}`}</div>
                     <div style="font-size: 20px; font-weight: 700; color: #18181b; margin: 0 0 16px;">
                       <a href="${escapeHtml(contentUrl)}" style="color: #18181b; text-decoration: none;">${escapeHtml(payload.contentTitle)}</a>
                     </div>
@@ -801,7 +807,7 @@ export function renderCommentActivityEmail(args: {
                       <tr>
                         <td style="padding: 18px;">
                           <div style="font-size: 14px; font-weight: 600; color: #18181b; margin: 0 0 8px;">
-                            ${escapeHtml(payload.commenterName)} commented:
+                            ${escapeHtml(payload.commenterName)} ${isReply ? "replied:" : "commented:"}
                           </div>
                           <div style="font-size: 14px; line-height: 1.6; color: #52525b; margin: 0 0 16px;">
                             "${escapeHtml(truncatedSnippet)}"
@@ -814,7 +820,7 @@ export function renderCommentActivityEmail(args: {
                 </tr>
                 <tr>
                   <td style="padding: 0 28px 28px; font-size: 12px; line-height: 1.6; color: #71717a;">
-                    You're receiving this because someone commented on your ${escapeHtml(contentLabel)}. This is an automated email.
+                    You're receiving this because someone ${isReply ? "replied to your comment" : `commented on your ${escapeHtml(contentLabel)}`}. This is an automated email.
                     <a href="${escapeHtml(profileUrl)}" style="color: #71717a;">Manage your email preferences</a>
                   </td>
                 </tr>
@@ -827,17 +833,23 @@ export function renderCommentActivityEmail(args: {
   `.trim();
 
   const text = [
-    `Garden — New comment on your ${contentLabel}`,
+    isReply
+      ? `Garden — New reply on ${contentLabel}`
+      : `Garden — New comment on your ${contentLabel}`,
     "",
     `Hi ${recipientName},`,
     "",
-    `${payload.commenterName} commented on your ${contentLabel} "${payload.contentTitle}":`,
+    isReply
+      ? `${payload.commenterName} replied to your comment on "${payload.contentTitle}":`
+      : `${payload.commenterName} commented on your ${contentLabel} "${payload.contentTitle}":`,
     "",
     `"${truncatedSnippet}"`,
     "",
     `View it here: ${contentUrl}`,
     "",
-    `You're receiving this because someone commented on your ${contentLabel}. This is an automated email.`,
+    isReply
+      ? `You're receiving this because someone replied to your comment. This is an automated email.`
+      : `You're receiving this because someone commented on your ${contentLabel}. This is an automated email.`,
     `Manage your email preferences: ${profileUrl}`,
   ].join("\n");
 


### PR DESCRIPTION
## Summary
This PR adds email notification functionality when users receive replies to their comments. Previously, only top-level comments triggered notifications. Now, when someone replies to a comment, the original comment author receives a dedicated "reply" email notification.

## Key Changes

- **New `enqueueReplyEmail` function** in `commentNotifications.ts`:
  - Enqueues a `comment_activity` email specifically for reply scenarios
  - Includes deduplication logic to avoid spamming users with multiple reply emails within a time window
  - Skips notifications if the replier is the original comment author or if the recipient has disabled projectActivity emails

- **Updated `renderCommentActivityEmail` function** in `emailRenderer.ts`:
  - Added `isReply` optional field to `CommentActivityPayload` type
  - Customized email subject, preheader, and body text to distinguish replies from regular comments
  - Email now says "New reply on..." instead of "New comment on your..." for reply scenarios
  - Updated all user-facing text to reflect reply context (e.g., "replied to your comment" vs "commented on your")

- **Integrated reply notification** in `comments.ts`:
  - When a comment with a `parentCommentId` is added, the system now calls `enqueueReplyEmail`
  - Includes validation to ensure the parent comment exists, isn't deleted, and the replier isn't the original author or project owner

## Implementation Details

- Reply emails use the same `comment_activity` type as regular comment notifications but are distinguished by the `isReply` flag in the payload
- The deduplication window prevents multiple reply notifications from being sent to the same user in quick succession
- Email templates are fully customized for the reply context while maintaining the existing design and styling

https://claude.ai/code/session_01Euh5XTjMPy7cCBJemKVj4T