### PR TITLE
Make projectSpaces the authoritative primary-space lookup

### DIFF
--- a/app/(app)/project/[id]/edit/page.tsx
+++ b/app/(app)/project/[id]/edit/page.tsx
@@ -126,7 +126,7 @@ export default function EditProject({ params }: { params: Promise<{ id: string }
       } else {
         setLinks([{ url: "", label: "" }]);
       }
-      setSelectedFocusArea(project.focusAreaId ?? null);
+      setSelectedFocusArea(project.focusArea?._id ?? null);
       if (project.additionalFocusAreas) {
         setAdditionalSpaces(project.additionalFocusAreas.map((fa: { _id: Id<"focusAreas"> }) => fa._id));
       }

--- a/convex/digests.ts
+++ b/convex/digests.ts
@@ -3,6 +3,7 @@ import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { isEmailEnabled } from "./emails";
+import { getAllSpacesForProject } from "./projects/spaces";
 
 const BATCH_SIZE = 50;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -271,35 +272,22 @@ export const gatherUserDigestData = internalQuery({
       const focusArea = await ctx.db.get(follow.focusAreaId);
       if (!focusArea || !focusArea.isActive) continue;
 
-      // Top projects in this space created during the period (primary + secondary)
-      const primaryProjects = await ctx.db
-        .query("projects")
-        .withIndex("by_status_focusArea_hotScore", (q) =>
-          q.eq("status", "active").eq("focusAreaId", focusArea._id)
-        )
+      // All projects in this space (primary + secondary), sorted by hotScore
+      const spaceRows = await ctx.db
+        .query("projectSpaces")
+        .withIndex("by_focusArea_hotScore", (q) => q.eq("focusAreaId", focusArea._id))
         .order("desc")
         .collect();
 
-      // Also include secondary-tagged projects
-      const secondaryRows = await ctx.db
-        .query("projectSpaces")
-        .withIndex("by_focusArea", (q) => q.eq("focusAreaId", focusArea._id))
-        .collect();
-
-      const primaryIds = new Set(primaryProjects.map((p) => p._id));
-      const secondaryProjectDocs = (
+      const allSpaceProjects = (
         await Promise.all(
-          secondaryRows
-            .filter((row) => !primaryIds.has(row.projectId))
-            .map(async (row) => {
-              const p = await ctx.db.get(row.projectId);
-              if (!p || p.status !== "active") return null;
-              return p;
-            })
+          spaceRows.map(async (row) => {
+            const p = await ctx.db.get(row.projectId);
+            if (!p || p.status !== "active") return null;
+            return p;
+          })
         )
       ).filter((p): p is NonNullable<typeof p> => p !== null);
-
-      const allSpaceProjects = [...primaryProjects, ...secondaryProjectDocs];
 
       const newSpaceProjects = allSpaceProjects.filter(
         (p) => p._creationTime >= periodStart && p._creationTime < periodEnd
@@ -360,17 +348,17 @@ export const gatherUserDigestData = internalQuery({
 
     const topProjects: PlatformHighlights["topProjects"] = [];
     for (const project of trendingProjectDocs) {
-      const [creator, focusArea] = await Promise.all([
+      const [creator, spaces] = await Promise.all([
         ctx.db.get(project.userId),
-        project.focusAreaId ? ctx.db.get(project.focusAreaId) : null,
+        getAllSpacesForProject(ctx, project._id),
       ]);
       topProjects.push({
         projectId: project._id,
         projectName: project.name,
         upvotes: project.upvotes,
         creatorName: creator?.name ?? "Unknown",
-        spaceName: focusArea?.name ?? null,
-        spaceIcon: focusArea?.icon ?? null,
+        spaceName: spaces.primary?.name ?? null,
+        spaceIcon: spaces.primary?.icon ?? null,
       });
     }
 

--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -35,7 +35,6 @@ export {
 export {
   list,
   listPaginated,
-  listPaginatedBySpace,
   getUserProjects,
   getByUserId,
   getAdoptedByUser,
@@ -74,6 +73,8 @@ export {
   backfillProjectSpaces,
   migrateClearFocusAreasAction,
   migrateClearFocusAreas,
+  clearFocusAreaIdFromProjectsAction,
+  clearFocusAreaIdFromProjects,
   migrateReadinessStatusAction,
   migrateReadinessStatus,
 } from "./projects/migrations";

--- a/convex/projects/helpers.ts
+++ b/convex/projects/helpers.ts
@@ -1,6 +1,6 @@
 import type { Id, Doc } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
-import { getSecondarySpacesForProject } from "./spaces";
+import { getAllSpacesForProject } from "./spaces";
 
 const HOT_SCORE_GRAVITY = 1.0;
 const HOT_SCORE_AGE_OFFSET = 2;
@@ -25,21 +25,9 @@ export async function enrichProjects(
   projects: Doc<"projects">[],
   userId: Id<"users"> | undefined
 ) {
-  const focusAreaIds = Array.from(
-    new Set(projects.map((project) => project.focusAreaId).filter((id): id is Id<"focusAreas"> => id !== undefined))
-  );
-  const focusAreaDocs = await Promise.all(
-    focusAreaIds.map((id) => ctx.db.get(id))
-  );
-  const focusAreaMap = new Map(
-    focusAreaDocs
-      .filter((fa): fa is NonNullable<typeof fa> => fa !== null)
-      .map((fa) => [fa._id, fa])
-  );
-
   return Promise.all(
     projects.map(async (project) => {
-      const [upvotes, comments, creator, team, mediaFiles, adoptions] = await Promise.all([
+      const [upvotes, comments, creator, team, mediaFiles, adoptions, spaces] = await Promise.all([
         ctx.db
           .query("upvotes")
           .withIndex("by_project", (q) => q.eq("projectId", project._id))
@@ -61,6 +49,7 @@ export async function enrichProjects(
           .withIndex("by_project", (q) => q.eq("projectId", project._id))
           .order("desc")
           .collect(),
+        getAllSpacesForProject(ctx, project._id),
       ]);
 
       const previewMedia = await Promise.all(
@@ -72,27 +61,16 @@ export async function enrichProjects(
         }))
       );
 
-      const focusAreaDoc = project.focusAreaId ? focusAreaMap.get(project.focusAreaId) : null;
-      const focusArea = focusAreaDoc ? {
-        _id: focusAreaDoc._id,
-        name: focusAreaDoc.name,
-        group: focusAreaDoc.group,
-        icon: focusAreaDoc.icon,
-      } : null;
-
-      const [adoptersWithInfo, additionalFocusAreas] = await Promise.all([
-        Promise.all(
-          adoptions.slice(0, 4).map(async (adoption) => {
-            const user = await ctx.db.get(adoption.userId);
-            return {
-              _id: adoption.userId,
-              name: user?.name ?? "Unknown User",
-              avatarUrl: user?.avatarUrlId ?? "",
-            };
-          })
-        ),
-        getSecondarySpacesForProject(ctx, project._id),
-      ]);
+      const adoptersWithInfo = await Promise.all(
+        adoptions.slice(0, 4).map(async (adoption) => {
+          const user = await ctx.db.get(adoption.userId);
+          return {
+            _id: adoption.userId,
+            name: user?.name ?? "Unknown User",
+            avatarUrl: user?.avatarUrlId ?? "",
+          };
+        })
+      );
 
       return {
         ...project,
@@ -103,8 +81,8 @@ export async function enrichProjects(
         hasUpvoted: userId ? upvotes.some((u) => u.userId === userId) : false,
         creatorName: creator?.name ?? "Unknown User",
         creatorAvatar: creator?.avatarUrlId ?? "",
-        focusArea,
-        additionalFocusAreas,
+        focusArea: spaces.primary,
+        additionalFocusAreas: spaces.secondary,
         previewMedia,
         adoptionCount: adoptions.length,
         adopters: adoptersWithInfo,

--- a/convex/projects/lifecycle.ts
+++ b/convex/projects/lifecycle.ts
@@ -115,7 +115,6 @@ export const createProject = internalMutationFromFunctions({
     status: v.union(v.literal("pending"), v.literal("active")),
     userId: v.id("users"),
     links: v.optional(v.array(v.object({ url: v.string(), label: v.optional(v.string()) }))),
-    focusAreaId: v.optional(v.id("focusAreas")),
     readinessStatus: v.union(v.literal("just_an_idea"), v.literal("early_prototype"), v.literal("mostly_working"), v.literal("ready_to_use")),
     pinned: v.optional(v.boolean()),
   },
@@ -134,7 +133,6 @@ export const createProject = internalMutationFromFunctions({
       status: args.status,
       userId: args.userId,
       links: args.links,
-      focusAreaId: args.focusAreaId,
       readinessStatus: args.readinessStatus,
       pinned: args.pinned ?? false,
     });
@@ -166,7 +164,6 @@ export const updateProjectFields = internalMutationFromFunctions({
     name: v.string(),
     summary: v.optional(v.string()),
     links: v.optional(v.array(v.object({ url: v.string(), label: v.optional(v.string()) }))),
-    focusAreaId: v.optional(v.id("focusAreas")),
     readinessStatus: v.union(v.literal("just_an_idea"), v.literal("early_prototype"), v.literal("mostly_working"), v.literal("ready_to_use")),
   },
   handler: async (ctx, args) => {
@@ -174,7 +171,6 @@ export const updateProjectFields = internalMutationFromFunctions({
       name: args.name,
       summary: args.summary,
       links: args.links,
-      focusAreaId: args.focusAreaId,
       readinessStatus: args.readinessStatus,
     });
   },
@@ -253,7 +249,6 @@ export const create = action({
         name: args.name,
         summary: args.summary,
         links: args.links,
-        focusAreaId: args.focusAreaId,
         readinessStatus: args.readinessStatus,
         status: "pending" as const,
         userId: user._id,
@@ -327,7 +322,6 @@ export const updateProject = action({
       name: args.name,
       summary: args.summary,
       links: args.links,
-      focusAreaId: args.focusAreaId,
       readinessStatus: args.readinessStatus,
     });
 

--- a/convex/projects/listing.ts
+++ b/convex/projects/listing.ts
@@ -1,10 +1,10 @@
 import { query } from "../_generated/server";
 import { v } from "convex/values";
 import { paginationOptsValidator } from "convex/server";
-import type { Id, Doc } from "../_generated/dataModel";
+import type { Doc } from "../_generated/dataModel";
 import { getCurrentUser } from "../users";
 import { enrichProjects } from "./helpers";
-import { getSecondarySpacesForProject } from "./spaces";
+import { getAllSpacesForProject } from "./spaces";
 
 export const list = query({
   args: {},
@@ -14,48 +14,34 @@ export const list = query({
       .withIndex("by_status", (q) => q.eq("status", "active"))
       .collect();
 
-    const focusAreaIds = Array.from(
-      new Set(projects.map((project) => project.focusAreaId).filter((id): id is Id<"focusAreas"> => id !== undefined))
-    );
-    const focusAreaDocs = await Promise.all(
-      focusAreaIds.map((id) => ctx.db.get(id))
-    );
-    const focusAreaMap = new Map(
-      focusAreaDocs
-        .filter((fa): fa is NonNullable<typeof fa> => fa !== null)
-        .map((fa) => [fa._id, fa])
-    );
-
     const currentUser = await getCurrentUser(ctx);
     const userId = currentUser?._id;
 
     const projectsWithCounts = await Promise.all(
       projects.map(async (project) => {
-        const upvotes = await ctx.db
-          .query("upvotes")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .collect();
-        const comments = await ctx.db
-          .query("comments")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .filter((q) => q.neq(q.field("isDeleted"), true))
-          .collect();
-        let hasUpvoted = false;
-        if (userId) {
-          const userUpvote = upvotes.find((u) => u.userId === userId);
-          hasUpvoted = !!userUpvote;
-        }
-        const creator = await ctx.db.get(project.userId);
+        const [upvotes, comments, creator, mediaFiles, spaces] = await Promise.all([
+          ctx.db
+            .query("upvotes")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .collect(),
+          ctx.db
+            .query("comments")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .filter((q) => q.neq(q.field("isDeleted"), true))
+            .collect(),
+          ctx.db.get(project.userId),
+          ctx.db
+            .query("mediaFiles")
+            .withIndex("by_project_ordered", (q) => q.eq("projectId", project._id))
+            .order("asc")
+            .collect(),
+          getAllSpacesForProject(ctx, project._id),
+        ]);
         let teamName = "";
         if (project.teamId) {
           const team = await ctx.db.get(project.teamId);
           teamName = team?.name ?? "";
         }
-        const mediaFiles = await ctx.db
-          .query("mediaFiles")
-          .withIndex("by_project_ordered", (q) => q.eq("projectId", project._id))
-          .order("asc")
-          .collect();
         const previewMedia = await Promise.all(
           mediaFiles.map(async (media) => ({
             _id: media._id,
@@ -64,22 +50,15 @@ export const list = query({
             url: await ctx.storage.getUrl(media.storageId),
           }))
         );
-        const focusAreaDoc = project.focusAreaId ? focusAreaMap.get(project.focusAreaId) : null;
-        const focusArea = focusAreaDoc ? {
-          _id: focusAreaDoc._id,
-          name: focusAreaDoc.name,
-          group: focusAreaDoc.group,
-          icon: focusAreaDoc.icon,
-        } : null;
         return {
           ...project,
           team: teamName,
           upvotes: upvotes.length,
           commentCount: comments.length,
-          hasUpvoted,
+          hasUpvoted: userId ? upvotes.some((u) => u.userId === userId) : false,
           creatorName: creator?.name ?? "Unknown User",
           creatorAvatar: creator?.avatarUrlId ?? "",
-          focusArea,
+          focusArea: spaces.primary,
           previewMedia,
         };
       })
@@ -130,28 +109,6 @@ export const listPaginated = query({
   },
 });
 
-export const listPaginatedBySpace = query({
-  args: {
-    paginationOpts: paginationOptsValidator,
-    focusAreaId: v.id("focusAreas"),
-  },
-  handler: async (ctx, args) => {
-    const currentUser = await getCurrentUser(ctx);
-    const userId = currentUser?._id;
-    const paginatedResult = await ctx.db
-      .query("projects")
-      .withIndex("by_status_focusArea_hotScore", (q) =>
-        q.eq("status", "active").eq("focusAreaId", args.focusAreaId)
-      )
-      .order("desc")
-      .paginate(args.paginationOpts);
-    const enrichedProjects = await enrichProjects(ctx, paginatedResult.page, userId);
-    return {
-      ...paginatedResult,
-      page: enrichedProjects,
-    };
-  },
-});
 
 export const getUserProjects = query({
   args: {},
@@ -410,14 +367,7 @@ export const getById = query({
       const team = await ctx.db.get(project.teamId);
       teamName = team?.name ?? "";
     }
-    const focusAreaDoc = project.focusAreaId ? await ctx.db.get(project.focusAreaId) : null;
-    const focusArea = focusAreaDoc ? {
-      _id: focusAreaDoc._id,
-      name: focusAreaDoc.name,
-      group: focusAreaDoc.group,
-      icon: focusAreaDoc.icon,
-    } : null;
-    const [adoptersWithInfo, additionalFocusAreas] = await Promise.all([
+    const [adoptersWithInfo, spaces] = await Promise.all([
       Promise.all(
         adoptions.slice(0, 6).map(async (adoption) => {
           const user = await ctx.db.get(adoption.userId);
@@ -428,7 +378,7 @@ export const getById = query({
           };
         })
       ),
-      getSecondarySpacesForProject(ctx, args.projectId),
+      getAllSpacesForProject(ctx, args.projectId),
     ]);
     return {
       ...project,
@@ -438,8 +388,8 @@ export const getById = query({
       hasUpvoted,
       creatorName: creator?.name ?? "Unknown User",
       creatorAvatar: creator?.avatarUrlId ?? "",
-      focusArea,
-      additionalFocusAreas,
+      focusArea: spaces.primary,
+      additionalFocusAreas: spaces.secondary,
       adoptionCount: adoptions.length,
       adopters: adoptersWithInfo,
       hasAdopted,

--- a/convex/projects/migrations.ts
+++ b/convex/projects/migrations.ts
@@ -89,6 +89,27 @@ export const migrateClearFocusAreas = internalMutationFromFunctions({
   },
 });
 
+export const clearFocusAreaIdFromProjectsAction = action({
+  args: {},
+  handler: async (ctx): Promise<{ updated: number }> => {
+    return await ctx.runMutation(internal.projects.clearFocusAreaIdFromProjects, {});
+  },
+});
+
+export const clearFocusAreaIdFromProjects = internalMutationFromFunctions({
+  args: {},
+  handler: async (ctx) => {
+    const projects = await ctx.db.query("projects").collect();
+    let updated = 0;
+    for (const project of projects) {
+      if (project.focusAreaId === undefined) continue;
+      await ctx.db.patch(project._id, { focusAreaId: undefined });
+      updated++;
+    }
+    return { updated };
+  },
+});
+
 export const migrateReadinessStatusAction = action({
   args: {},
   handler: async (ctx): Promise<{ updated: number }> => {

--- a/convex/projects/spaces.ts
+++ b/convex/projects/spaces.ts
@@ -122,7 +122,7 @@ export async function propagateHotScoreToMemberships(
 
 // ─── Shared query helper ─────────────────────────────────────────────────────
 
-export async function getSecondarySpacesForProject(
+export async function getAllSpacesForProject(
   ctx: QueryCtx,
   projectId: Id<"projects">
 ) {
@@ -131,24 +131,22 @@ export async function getSecondarySpacesForProject(
     .withIndex("by_project", (q) => q.eq("projectId", projectId))
     .collect();
 
-  const secondaryRows = rows.filter((row) => !row.isPrimary);
-
-  const spaces = await Promise.all(
-    secondaryRows.map(async (row) => {
+  const resolved = await Promise.all(
+    rows.map(async (row) => {
       const fa = await ctx.db.get(row.focusAreaId);
       if (!fa || !fa.isActive) return null;
       return {
-        _id: fa._id,
-        name: fa.name,
-        group: fa.group,
-        icon: fa.icon,
+        isPrimary: row.isPrimary,
+        space: { _id: fa._id, name: fa.name, group: fa.group, icon: fa.icon },
       };
     })
   );
 
-  return spaces.filter(
-    (s): s is NonNullable<typeof s> => s !== null
-  );
+  const valid = resolved.filter((r): r is NonNullable<typeof r> => r !== null);
+  return {
+    primary: valid.find((r) => r.isPrimary)?.space ?? null,
+    secondary: valid.filter((r) => !r.isPrimary).map((r) => r.space),
+  };
 }
 
 // ─── Paginated space feed (primary + secondary, sorted by hotScore) ──────────

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -33,8 +33,7 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_teamId", ["teamId"])
     .index("by_status_engagement", ["status", "engagementScore"])
-    .index("by_status_hotScore", ["status", "hotScore"])
-    .index("by_status_focusArea_hotScore", ["status", "focusAreaId", "hotScore"]),
+    .index("by_status_hotScore", ["status", "hotScore"]),
   mediaFiles: defineTable({
     projectId: v.id("projects"),
     storageId: v.id("_storage"),

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -107,7 +107,7 @@ export const seed = internalMutation({
         summary: "Discover competitor signals across the web.",
         userId: userIds[0],
         teamId: teamIds[0],
-        focusAreaId: focusAreaIds[0],
+        primaryFocusAreaId: focusAreaIds[0],
         status: "active" as const,
         readinessStatus: "ready_to_use" as const,
         upvotes: 2,
@@ -121,7 +121,7 @@ export const seed = internalMutation({
         summary: "Plan and execute launch playbooks.",
         userId: userIds[1],
         teamId: teamIds[0],
-        focusAreaId: focusAreaIds[1],
+        primaryFocusAreaId: focusAreaIds[1],
         status: "active" as const,
         readinessStatus: "early_prototype" as const,
         upvotes: 1,
@@ -135,7 +135,7 @@ export const seed = internalMutation({
         summary: "Organize user research in one place.",
         userId: userIds[2],
         teamId: teamIds[1],
-        focusAreaId: focusAreaIds[2],
+        primaryFocusAreaId: focusAreaIds[2],
         status: "pending" as const,
         readinessStatus: "mostly_working" as const,
         upvotes: 1,
@@ -149,7 +149,7 @@ export const seed = internalMutation({
         summary: "Track privacy posture and compliance gaps.",
         userId: userIds[3],
         teamId: undefined,
-        focusAreaId: focusAreaIds[3],
+        primaryFocusAreaId: focusAreaIds[3],
         status: "active" as const,
         readinessStatus: "ready_to_use" as const,
         upvotes: 3,
@@ -163,7 +163,7 @@ export const seed = internalMutation({
         summary: undefined,
         userId: userIds[8],
         teamId: teamIds[2],
-        focusAreaId: focusAreaIds[4],
+        primaryFocusAreaId: focusAreaIds[4],
         status: "pending" as const,
         readinessStatus: "ready_to_use" as const,
         upvotes: 0,
@@ -183,7 +183,6 @@ export const seed = internalMutation({
         summary: project.summary,
         userId: project.userId,
         teamId: project.teamId,
-        focusAreaId: project.focusAreaId,
         status: project.status,
         readinessStatus: project.readinessStatus,
         upvotes: project.upvotes,
@@ -195,6 +194,14 @@ export const seed = internalMutation({
         allFields,
       });
       projectIds.push(id);
+      if (project.primaryFocusAreaId) {
+        await ctx.db.insert("projectSpaces", {
+          projectId: id,
+          focusAreaId: project.primaryFocusAreaId,
+          isPrimary: true,
+          hotScore: project.hotScore ?? 0,
+        });
+      }
     }
 
     // 6. Media Files


### PR DESCRIPTION
Replace focusAreaId on projects table with projectSpaces as the single source
of truth. Projects now read primary and secondary spaces from projectSpaces
instead of denormalizing focusAreaId.

Changes:
- getAllSpacesForProject replaces getSecondarySpacesForProject
- Remove focusAreaId writes from createProject and updateProjectFields
- Remove by_status_focusArea_hotScore index (now uses projectSpaces)
- Update digests and listing queries to use projectSpaces
- Add clearFocusAreaIdFromProjects migration (idempotent patch-based)
- Update seed.ts to populate projectSpaces instead of focusAreaId

The focusAreaId field remains in schema (optional) for now; run the
clearFocusAreaIdFromProjects migration after verifying the changes.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>