### PR TITLE
Restore carousel expand behavior in ProjectRow

### DIFF
--- a/components/ProjectRow.tsx
+++ b/components/ProjectRow.tsx
@@ -109,8 +109,8 @@ export function ProjectRow({
 
       {/* Media carousel OR summary - not both */}
       {hasMedia ? (
-        <div className="w-full max-w-2xl">
-          <ProjectMediaCarousel media={project.previewMedia} allowExpand={false} />
+        <div className="w-full max-w-2xl" onClick={(e) => e.stopPropagation()}>
+          <ProjectMediaCarousel media={project.previewMedia} />
         </div>
       ) : project.summary ? (
         <p className="text-sm leading-5 text-zinc-600 line-clamp-2 break-words">


### PR DESCRIPTION
Re-enable the expand/lightbox feature on the media carousel in project
list items. Clicks on the carousel now open the lightbox instead of
propagating up to navigate to the project detail page.

https://claude.ai/code/session_01ALbvxucFXemxQX3zZqxFLA