### PR TITLE
Fix card text overflow in chat display components

### DIFF
--- a/components/chat/ProjectCardsDisplay.tsx
+++ b/components/chat/ProjectCardsDisplay.tsx
@@ -115,7 +115,7 @@ export function ProjectCardsDisplay({
                       )}
                     </div>
                     <CardHeader className="space-y-1 px-3 pb-3 pt-2">
-                      <CardTitle className="flex items-center gap-1 text-sm font-medium">
+                      <CardTitle className="flex items-center gap-1 text-sm font-medium min-w-0 overflow-hidden">
                         <span className="truncate">{project.name}</span>
                         <ArrowUpRight className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
                       </CardTitle>

--- a/components/chat/ThreadCardsDisplay.tsx
+++ b/components/chat/ThreadCardsDisplay.tsx
@@ -76,7 +76,7 @@ export function ThreadCardsDisplay({
                     )}
                     <span>{getRelativeTime(thread.createdAt)}</span>
                   </div>
-                  <CardTitle className="flex items-center gap-1 text-sm font-medium">
+                  <CardTitle className="flex items-center gap-1 text-sm font-medium min-w-0 overflow-hidden">
                     <span className="truncate">{thread.title}</span>
                     <ArrowUpRight className="h-3 w-3 flex-shrink-0 text-muted-foreground" />
                   </CardTitle>


### PR DESCRIPTION
## Summary
- Add `min-w-0 overflow-hidden` to `CardTitle` in `ProjectCardsDisplay` and `ThreadCardsDisplay` so title text properly truncates instead of overflowing the card boundary
- Fixes project cards clipping long text and thread cards expanding horizontally beyond the chat message container

## Test plan
- [ ] Query the chatbot for projects with long names — titles should truncate with ellipsis
- [ ] Query for threads with long titles — cards should stay within the message bubble width
- [ ] Verify short titles still display normally without clipping

https://claude.ai/code/session_01UV3kMVaWsn2PhZwLjWRPTT