### PR TITLE
Remove deprecated projects.upvotes field from schema

### DIFF
--- a/convex/projects.ts
+++ b/convex/projects.ts
@@ -71,7 +71,6 @@ export {
 } from "./projects/spaces";
 
 export {
-  removeProjectUpvotesField,
   migrateReadinessStatusAction,
   migrateReadinessStatus,
   getAllProjectIds,

--- a/convex/projects/lifecycle.ts
+++ b/convex/projects/lifecycle.ts
@@ -63,7 +63,6 @@ export const populateProjectDetails = internalQuery({
         name: v.string(),
         summary: v.optional(v.string()),
         teamId: v.optional(v.id("teams")),
-        upvotes: v.optional(v.number()),
         entryId: v.optional(v.string()),
         status: v.union(v.literal("pending"), v.literal("active")),
         userId: v.id("users"),

--- a/convex/projects/migrations.ts
+++ b/convex/projects/migrations.ts
@@ -4,27 +4,6 @@ import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { rag } from "../rag";
 
-// ─── Remove deprecated projects.upvotes field ───────────────────────────────
-// Two-step migration:
-// Step 1 (this deployment): Deploy code with upvotes as v.optional(v.number()) in schema
-// Step 2 (after deployment): Run internal.projects.removeProjectUpvotesField from Convex dashboard
-// Step 3 (follow-up PR): Remove upvotes field from schema.ts entirely
-
-export const removeProjectUpvotesField = internalMutationFromFunctions({
-  args: {},
-  handler: async (ctx) => {
-    const projects = await ctx.db.query("projects").collect();
-    let updated = 0;
-    for (const project of projects) {
-      if (project.upvotes !== undefined) {
-        await ctx.db.patch(project._id, { upvotes: undefined });
-        updated++;
-      }
-    }
-    return { updated };
-  },
-});
-
 export const migrateReadinessStatusAction = internalAction({
   args: {},
   handler: async (ctx): Promise<{ updated: number }> => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,7 +6,6 @@ export default defineSchema({
     name: v.string(),
     summary: v.optional(v.string()),
     teamId: v.optional(v.id("teams")),
-    upvotes: v.optional(v.number()),
     viewCount: v.optional(v.number()),
     entryId: v.optional(v.string()),
     status: v.union(v.literal("pending"), v.literal("active")),


### PR DESCRIPTION
Migration was already run via Convex dashboard to unset the field on all existing documents. Now safe to remove from schema, validator, and the completed migration function.

https://claude.ai/code/session_01QENAuoY8XxwwV2KUVWguJk