### PR TITLE
Strip HTML from project summaries and improve image upload UX

### DIFF
--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -76,7 +76,7 @@ export function RichTextEditor({
   // Intercept paste/drop of images to prevent Quill from embedding base64 data URLs,
   // which can exceed Convex's 1 MiB document size limit.
   useEffect(() => {
-    if (!onImageUpload || !wrapperRef.current) return;
+    if (!wrapperRef.current) return;
 
     const blockImageTransfer = (e: ClipboardEvent | DragEvent) => {
       const files =
@@ -90,7 +90,11 @@ export function RichTextEditor({
       if (hasImage) {
         e.preventDefault();
         e.stopPropagation();
-        toast.info("Use the image button in the toolbar to add images.");
+        toast.info(
+          onImageUploadRef.current
+            ? "Use the image button in the toolbar to add images."
+            : "Images are not supported in this editor."
+        );
       }
     };
 
@@ -102,18 +106,18 @@ export function RichTextEditor({
       el.removeEventListener("paste", blockImageTransfer as EventListener, true);
       el.removeEventListener("drop", blockImageTransfer as EventListener, true);
     };
-  }, [onImageUpload]);
+  }, []);
 
   // Safety net: strip any base64 images that slip past the paste/drop blocker.
   const handleChange = useCallback(
     (html: string) => {
-      if (onImageUpload && html.includes("src=\"data:")) {
+      if (html.includes("src=\"data:")) {
         onChange(html.replace(/<img[^>]+src="data:[^"]*"[^>]*>/g, ""));
         return;
       }
       onChange(html);
     },
-    [onChange, onImageUpload]
+    [onChange]
   );
 
   const modules = useMemo(() => {

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -3,6 +3,21 @@ import { customCtx, customMutation } from "convex-helpers/server/customFunctions
 import { internalMutation as rawMutation } from "./_generated/server";
 import { DataModel } from "./_generated/dataModel";
 
+function stripHtml(html: string): string {
+  return html
+    .replace(/<\/(p|h[1-6]|li|div|blockquote|pre|ol|ul)>/gi, " ")
+    .replace(/<(p|h[1-6]|li|div|blockquote|pre|ol|ul|br)[^>]*\/?>/gi, " ")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 const triggers = new Triggers<DataModel>();
 
 triggers.register("projects", async (ctx, change) => {
@@ -14,7 +29,8 @@ triggers.register("projects", async (ctx, change) => {
       teamName = team?.name ?? "";
     }
 
-    const allFields = `${change.newDoc.name} ${change.newDoc.summary || ""} ${teamName}`.trim();
+    const summaryText = change.newDoc.summary ? stripHtml(change.newDoc.summary) : "";
+    const allFields = `${change.newDoc.name} ${summaryText} ${teamName}`.trim();
 
     if (change.newDoc.allFields !== allFields) {
       await ctx.db.patch(change.id, { allFields });


### PR DESCRIPTION
## Summary
This PR improves text handling in project search indexing and refines the image upload experience in the rich text editor.

## Key Changes

- **Added HTML stripping utility**: Introduced `stripHtml()` function in `convex/functions.ts` that removes HTML tags and decodes common HTML entities from text content
- **Updated project indexing**: Modified the project trigger to strip HTML from summary fields before storing in the `allFields` search index, ensuring cleaner text indexing
- **Improved image upload messaging**: Updated `RichTextEditor.tsx` to provide context-aware feedback when users attempt to paste/drop images:
  - Shows "Use the image button in the toolbar to add images" when image uploads are enabled
  - Shows "Images are not supported in this editor" when image uploads are disabled
- **Simplified effect dependencies**: Removed unnecessary `onImageUpload` dependency from useEffect hooks, relying instead on `onImageUploadRef.current` for runtime checks

## Implementation Details

The `stripHtml()` function handles:
- Removal of block-level HTML tags (p, h1-h6, div, blockquote, etc.) with space preservation
- Decoding of HTML entities (&nbsp;, &amp;, &lt;, &gt;, &quot;, &#39;)
- Normalization of whitespace to single spaces
- Trimming of leading/trailing whitespace

The image upload UX improvements use a ref-based approach to avoid unnecessary effect re-runs while still providing dynamic messaging based on the current upload capability.

https://claude.ai/code/session_01MrsXiseksJAoyQm5EmbXkA