### PR TITLE
Fix project upload size limit error

### DIFF
--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -93,7 +93,7 @@ export function RichTextEditor({
         toast.info(
           onImageUploadRef.current
             ? "Use the image button in the toolbar to add images."
-            : "Images are not supported in this editor."
+            : "To add images, use the Screenshots and Clips field in the Files and Media tab."
         );
       }
     };


### PR DESCRIPTION
## Summary

Fixes the Convex 1 MiB document size limit error that occurs when users upload projects with large descriptions. Root cause: base64 images in the summary were being stored twice (once in the field, once in the denormalized `allFields` search index).

- **Block image paste/drop** in project description RTE and redirect users to the Screenshots and Clips field
- **Strip HTML tags** from summary when building the search index, storing only plain text
- **Update toast message** to guide users to the correct upload location

## Files Changed

- `components/RichTextEditor.tsx` — Fix paste/drop blocker and base64 safety net to work for all editors; update toast message
- `convex/functions.ts` — Strip HTML from summary in `allFields` trigger

## Testing

1. Try pasting an image into a project description — should see toast directing to Screenshots and Clips field
2. Submit a project with large formatted description — should not exceed 1 MiB document size limit