### PR TITLE
Show latest version date as project row timestamp

### DIFF
--- a/components/ProjectRow.tsx
+++ b/components/ProjectRow.tsx
@@ -93,7 +93,7 @@ export function ProjectRow({
             </Link>
           )}
         </div>
-        <span className="shrink-0 text-zinc-400">{getRelativeTime(project._creationTime)}</span>
+        <span className="shrink-0 text-zinc-400">{getRelativeTime(project.lastVersionAt ?? project._creationTime)}</span>
       </div>
 
       {/* Title */}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,7 @@ export type FocusArea = {
 export type ProjectRowData = {
   _id: Id<"projects">;
   _creationTime: number;
+  lastVersionAt?: number;
   name: string;
   summary?: string;
   team?: string;


### PR DESCRIPTION
The ProjectRow timestamp now reflects when the latest version was
published (lastVersionAt), falling back to the project's creation date
for projects with no versions. This gives a more accurate sense of
recency for actively maintained tools.

https://claude.ai/code/session_014TEQqBqSpgFF91N6KF8sAC