### PR TITLE
Fan out new projects to user feeds immediately on confirmation

### DIFF
--- a/convex/projects/lifecycle.ts
+++ b/convex/projects/lifecycle.ts
@@ -213,6 +213,13 @@ export const confirmProject = mutation({
       });
     }
 
+    // Inject into all users' personalized feeds immediately
+    await ctx.scheduler.runAfter(
+      0,
+      internal.userAffinities.injectNewProjectIntoFeeds,
+      { projectId: args.projectId }
+    );
+
     // Process @mentions in the description when project goes live
     if (project.summary) {
       const mentionedUserIds = parseMentionsFromHtml(project.summary);

--- a/convex/userAffinities.ts
+++ b/convex/userAffinities.ts
@@ -383,6 +383,120 @@ export const backfillAllFeeds = internalMutation({
   },
 });
 
+// ─── New-project fan-out ────────────────────────────────────────────────────
+// When a project is confirmed, inject it into all users' precomputed feeds
+// immediately so it appears without waiting for the next 6-hour cron cycle.
+
+const INJECT_BATCH_SIZE = 100;
+
+export const injectNewProjectIntoFeeds = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+    cursor: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const project = await ctx.db.get(args.projectId);
+    if (!project || project.status !== "active") return;
+
+    const now = Date.now();
+
+    // Shared reads: project's space memberships + creator (same for all users)
+    const memberships = await ctx.db
+      .query("projectSpaces")
+      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
+      .collect();
+    const creator = await ctx.db.get(project.userId);
+
+    // Paginate through all userAffinities docs
+    const result = await ctx.db
+      .query("userAffinities")
+      .paginate({ numItems: INJECT_BATCH_SIZE, cursor: args.cursor ?? null });
+
+    for (const affinity of result.page) {
+      // Skip if user already has an entry for this project
+      const existingEntry = await ctx.db
+        .query("userFeedEntries")
+        .withIndex("by_userId_projectId", (q) =>
+          q.eq("userId", affinity.userId).eq("projectId", args.projectId)
+        )
+        .first();
+      if (existingEntry) continue;
+
+      // Score the project against this user's affinity profile
+      const followedSpaceSet = new Set(
+        affinity.followedSpaceIds.map((id) => id as string)
+      );
+      const engagedCreatorSet = new Set(
+        affinity.engagedCreatorIds.map((id) => id as string)
+      );
+      const engagedProjectSet = new Set(
+        affinity.engagedProjectIds.map((id) => id as string)
+      );
+      const spaceLastEngagedAt = affinity.spaceLastEngagedAt ?? {};
+      const creatorLastEngagedAt = affinity.creatorLastEngagedAt ?? {};
+
+      let boost = 0;
+      let spaceBoostCount = 0;
+      for (const m of memberships) {
+        const spaceId = m.focusAreaId as string;
+        if (followedSpaceSet.has(spaceId)) {
+          boost += SPACE_BOOST * recencyWeight(spaceLastEngagedAt[spaceId], now);
+          spaceBoostCount++;
+          if (spaceBoostCount >= 2) break;
+        } else if (spaceLastEngagedAt[spaceId] !== undefined) {
+          boost +=
+            IMPLICIT_SPACE_BOOST *
+            recencyWeight(spaceLastEngagedAt[spaceId], now);
+          spaceBoostCount++;
+          if (spaceBoostCount >= 2) break;
+        }
+      }
+
+      if (engagedCreatorSet.has(project.userId as string)) {
+        boost +=
+          CREATOR_BOOST *
+          recencyWeight(
+            creatorLastEngagedAt[project.userId as string],
+            now
+          );
+      }
+
+      if (
+        affinity.department &&
+        creator?.department === affinity.department
+      ) {
+        boost += DEPARTMENT_BOOST;
+      }
+
+      if (engagedProjectSet.has(args.projectId as string)) {
+        boost += ENGAGED_PENALTY;
+      }
+
+      const clampedBoost = clamp(boost, MIN_BOOST, MAX_BOOST);
+      const personalizedScore = (project.hotScore ?? 0) * (1 + clampedBoost);
+
+      await ctx.db.insert("userFeedEntries", {
+        userId: affinity.userId,
+        projectId: args.projectId,
+        personalizedScore,
+        computedAt: now,
+      });
+    }
+
+    // Continue with next batch if there are more users
+    if (!result.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.userAffinities.injectNewProjectIntoFeeds,
+        {
+          projectId: args.projectId,
+          cursor: result.continueCursor,
+        }
+      );
+    }
+  },
+});
+
 // ─── Incremental update helpers ──────────────────────────────────────────────
 
 export async function incrementalAddEngagedProject(


### PR DESCRIPTION
## Summary
When a project is confirmed, it is now immediately injected into all users' personalized feeds rather than waiting for the next 6-hour cron cycle. This ensures new projects appear in users' feeds without delay.

## Key Changes
- Added `injectNewProjectIntoFeeds` internal mutation that:
  - Paginates through all user affinity profiles in batches of 100
  - Scores each new project against individual users' affinity profiles (spaces, creators, departments, engagement history)
  - Creates `userFeedEntries` for users who don't already have an entry for the project
  - Schedules continuation for the next batch if more users remain
- Updated `confirmProject` mutation to trigger the fan-out immediately after project confirmation via scheduler

## Implementation Details
- Reuses existing scoring logic (space boosts, creator boosts, department matching, recency weighting)
- Applies clamping to boost values and personalizes scores using the project's hot score
- Skips users who already have feed entries for the project to avoid duplicates
- Uses pagination with cursor-based continuation to handle large user bases efficiently
- Scheduled with 0ms delay to execute as soon as possible after confirmation

https://claude.ai/code/session_017VzXsyuqmuh3VXNzKa8LfF