### PR TITLE
Add catalog invite email template and queueing logic

### DIFF
--- a/convex/digests.ts
+++ b/convex/digests.ts
@@ -159,22 +159,9 @@ export const generateDigestBatch = internalAction({
   },
   handler: async (ctx, args) => {
     for (const userId of args.userIds) {
-      const digestData: DigestData = await ctx.runQuery(
-        internal.digests.gatherUserDigestData,
-        {
-          userId,
-          periodStart: args.periodStart,
-          periodEnd: args.periodEnd,
-        }
-      );
-
-      if (isDigestEmpty(digestData)) continue;
-
-      await ctx.runMutation(internal.digests.enqueueDigestEmail, {
+      await ctx.runMutation(internal.digests.enqueueCatalogInvite, {
         userId,
-        periodStart: args.periodStart,
         periodEnd: args.periodEnd,
-        digestData,
       });
     }
   },
@@ -412,6 +399,35 @@ export const gatherUserDigestData = internalQuery({
 // ─── Internal: enqueue digest email ───────────────────────────────────────────
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
+
+export const enqueueCatalogInvite = internalMutation({
+  args: {
+    userId: v.id("users"),
+    periodEnd: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const deduplicationWindow = args.periodEnd - ONE_HOUR_MS;
+    const existing = await ctx.db
+      .query("emailQueue")
+      .withIndex("by_userId_type_createdAt", (q) =>
+        q
+          .eq("userId", args.userId)
+          .eq("type", "catalog_invite")
+          .gte("createdAt", deduplicationWindow)
+      )
+      .first();
+
+    if (existing) return;
+
+    await ctx.db.insert("emailQueue", {
+      userId: args.userId,
+      type: "catalog_invite",
+      status: "pending",
+      payload: {},
+      createdAt: Date.now(),
+    });
+  },
+});
 
 export const enqueueDigestEmail = internalMutation({
   args: {

--- a/convex/emailRenderer.ts
+++ b/convex/emailRenderer.ts
@@ -953,6 +953,108 @@ export function renderFollowedProjectUpdateEmail(args: {
   return { subject, html, text };
 }
 
+// ─── Catalog Invite Email ────────────────────────────────────────────────────
+
+export function renderCatalogInviteEmail(args: {
+  recipientName: string;
+  baseUrl: string;
+  profileUrl: string;
+}): RenderedEmail {
+  const { recipientName, baseUrl, profileUrl } = args;
+  const subject = "Help grow Honda's digital resource library";
+  const preheader = "See what your colleagues have built — and share what you've made.";
+  const submitUrl = joinUrl(baseUrl, "/submit");
+  const homeUrl = joinUrl(baseUrl, "/");
+
+  const html = `
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>${escapeHtml(subject)}</title>
+      </head>
+      <body style="margin: 0; padding: 0; background-color: #f4f4f5; color: #18181b; font-family: Arial, sans-serif;">
+        <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
+          ${escapeHtml(preheader)}
+        </div>
+        <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: collapse; background-color: #f4f4f5;">
+          <tr>
+            <td align="center" style="padding: 24px 12px;">
+              <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="max-width: 640px; border-collapse: collapse; background-color: #ffffff; border-radius: 18px;">
+                <tr>
+                  <td style="padding: 28px 28px 24px; border-bottom: 1px solid #e4e4e7;">
+                    <div style="font-size: 28px; font-weight: 700; color: #166534; margin: 0 0 16px;">Garden</div>
+                    <div style="font-size: 24px; font-weight: 700; line-height: 1.3; color: #18181b; margin: 0 0 10px;">Hi ${escapeHtml(recipientName)},</div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 24px 28px 8px;">
+                    <div style="font-size: 15px; line-height: 1.7; color: #3f3f46; margin: 0 0 16px;">
+                      A lot of people at Honda are quietly building useful things. Garden is where that work becomes visible.
+                    </div>
+                    <div style="font-size: 15px; line-height: 1.7; color: #3f3f46; margin: 0 0 16px;">
+                      If you've built something that saves you time — a script, a dashboard, an automation, a template — Garden is a good home for it. Somebody else may be solving the same problem right now, and what you've already made could be the answer. And while you're there, take a look at what your colleagues have put together. You might find something that changes how you work.
+                    </div>
+                    <div style="font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #71717a; margin: 0 0 10px;">
+                      What's worth sharing
+                    </div>
+                    <ul style="padding-left: 20px; margin: 0 0 20px; font-size: 15px; line-height: 1.8; color: #3f3f46;">
+                      <li>Scripts and automations that cut down on repetitive work</li>
+                      <li>Dashboards and reports you've put together</li>
+                      <li>Templates, tools, or workflows others might find useful</li>
+                    </ul>
+                    <div style="font-size: 15px; line-height: 1.7; color: #3f3f46; margin: 0 0 24px;">
+                      It only takes a couple minutes to submit.
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 0 28px 28px;">
+                    <a href="${escapeHtml(submitUrl)}" style="display: inline-block; background-color: #166534; color: #ffffff; text-decoration: none; font-size: 14px; font-weight: 700; padding: 12px 18px; border-radius: 999px; margin-right: 10px;">Add a resource</a>
+                    <a href="${escapeHtml(homeUrl)}" style="display: inline-block; background-color: #ffffff; color: #166534; text-decoration: none; font-size: 14px; font-weight: 700; padding: 12px 18px; border-radius: 999px; border: 1.5px solid #166534;">Browse the library</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 0 28px 28px; font-size: 12px; line-height: 1.6; color: #71717a;">
+                    You're receiving this from Garden.
+                    <a href="${escapeHtml(profileUrl)}" style="color: #71717a;">Manage your email preferences</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+    </html>
+  `.trim();
+
+  const text = [
+    `Garden — Help grow Honda's digital resource library`,
+    "",
+    `Hi ${recipientName},`,
+    "",
+    "A lot of people at Honda are quietly building useful things. Garden is where that work becomes visible.",
+    "",
+    "If you've built something that saves you time — a script, a dashboard, an automation, a template — Garden is a good home for it. Somebody else may be solving the same problem right now, and what you've already made could be the answer. And while you're there, take a look at what your colleagues have put together. You might find something that changes how you work.",
+    "",
+    "What's worth sharing:",
+    "- Scripts and automations that cut down on repetitive work",
+    "- Dashboards and reports you've put together",
+    "- Templates, tools, or workflows others might find useful",
+    "",
+    "It only takes a couple minutes to submit.",
+    "",
+    `Add a resource: ${submitUrl}`,
+    `Browse the library: ${homeUrl}`,
+    "",
+    `You're receiving this from Garden.`,
+    `Manage your email preferences: ${profileUrl}`,
+  ].join("\n");
+
+  return { subject, html, text };
+}
+
 // ─── Mention Activity Email ──────────────────────────────────────────────────
 
 export function renderMentionEmail(args: {

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -17,6 +17,7 @@ import {
   renderFollowedCommentEmail,
   renderFollowedProjectUpdateEmail,
   renderMentionEmail,
+  renderCatalogInviteEmail,
   type WeeklyDigestPayload,
   type SpaceActivityPayload,
   type CommentActivityPayload,
@@ -144,6 +145,15 @@ export const sendEmail = internalAction({
       const rendered = renderMentionEmail({
         recipientName: recipient.name,
         payload: args.payload as MentionActivityPayload,
+        baseUrl,
+        profileUrl,
+      });
+      subject = rendered.subject;
+      html = rendered.html;
+      text = rendered.text;
+    } else if (args.type === "catalog_invite") {
+      const rendered = renderCatalogInviteEmail({
+        recipientName: recipient.name,
         baseUrl,
         profileUrl,
       });


### PR DESCRIPTION
## Summary
This PR adds a new email type for inviting users to contribute to the Garden catalog (Honda's digital resource library). It includes the email template renderer, queueing logic, and integration with the email sending pipeline.

## Key Changes
- **New email template**: Added `renderCatalogInviteEmail()` function in `emailRenderer.ts` that generates HTML and plain text versions of the catalog invite email with:
  - Personalized greeting
  - Description of Garden and its purpose
  - List of shareable resource types (scripts, dashboards, templates)
  - Call-to-action buttons for submitting and browsing resources
  - Email preference management link

- **Email queueing**: Added `enqueueCatalogInvite()` mutation in `digests.ts` that:
  - Queues catalog invite emails for users
  - Implements deduplication logic (1-hour window) to prevent duplicate invites
  - Uses the existing emailQueue infrastructure

- **Email sending integration**: Updated `sendEmail()` action in `emails.ts` to handle the new "catalog_invite" email type and render it with user-specific data

- **Digest batch refactoring**: Modified `generateDigestBatch()` to enqueue catalog invites instead of digest emails (appears to be a temporary change or migration)

## Implementation Details
- The email uses the existing Garden branding (green color scheme: #166534)
- Deduplication window is set to 1 hour before the period end to avoid sending duplicate invites
- The email payload is empty (`{}`) as all necessary data is derived from user context
- Follows the same email rendering pattern as other email types in the codebase

https://claude.ai/code/session_01LyZtmGubfmNnWtq5ZgR1do