### PR TITLE
Update catalog invite email with resource count and schedule

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -10,10 +10,10 @@ crons.interval(
   internal.projects.refreshHotScores
 );
 
-// Generate weekly digests every Friday at 12:00 PM EST (17:00 UTC)
+// Generate weekly digests every Monday at 11:00 AM EST (16:00 UTC)
 crons.weekly(
   "generate weekly digests",
-  { dayOfWeek: "friday", hourUTC: 17, minuteUTC: 0 },
+  { dayOfWeek: "monday", hourUTC: 16, minuteUTC: 0 },
   internal.digests.generateWeeklyDigests
 );
 

--- a/convex/digests.ts
+++ b/convex/digests.ts
@@ -158,10 +158,15 @@ export const generateDigestBatch = internalAction({
     periodEnd: v.number(),
   },
   handler: async (ctx, args) => {
+    const recentResourceCount: number = await ctx.runQuery(
+      internal.digests.getRecentResourceCount,
+      { periodStart: args.periodStart }
+    );
     for (const userId of args.userIds) {
       await ctx.runMutation(internal.digests.enqueueCatalogInvite, {
         userId,
         periodEnd: args.periodEnd,
+        recentResourceCount,
       });
     }
   },
@@ -400,10 +405,23 @@ export const gatherUserDigestData = internalQuery({
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
+export const getRecentResourceCount = internalQuery({
+  args: { periodStart: v.number() },
+  handler: async (ctx, args) => {
+    const recent = await ctx.db
+      .query("projects")
+      .withIndex("by_status_hotScore", (q) => q.eq("status", "active"))
+      .order("desc")
+      .collect();
+    return recent.filter((p) => p._creationTime >= args.periodStart).length;
+  },
+});
+
 export const enqueueCatalogInvite = internalMutation({
   args: {
     userId: v.id("users"),
     periodEnd: v.number(),
+    recentResourceCount: v.number(),
   },
   handler: async (ctx, args) => {
     const deduplicationWindow = args.periodEnd - ONE_HOUR_MS;
@@ -423,7 +441,7 @@ export const enqueueCatalogInvite = internalMutation({
       userId: args.userId,
       type: "catalog_invite",
       status: "pending",
-      payload: {},
+      payload: { recentResourceCount: args.recentResourceCount },
       createdAt: Date.now(),
     });
   },

--- a/convex/digests.ts
+++ b/convex/digests.ts
@@ -160,7 +160,7 @@ export const generateDigestBatch = internalAction({
   handler: async (ctx, args) => {
     const recentResourceCount: number = await ctx.runQuery(
       internal.digests.getRecentResourceCount,
-      { periodStart: args.periodStart }
+      {}
     );
     for (const userId of args.userIds) {
       await ctx.runMutation(internal.digests.enqueueCatalogInvite, {
@@ -406,14 +406,13 @@ export const gatherUserDigestData = internalQuery({
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 export const getRecentResourceCount = internalQuery({
-  args: { periodStart: v.number() },
-  handler: async (ctx, args) => {
-    const recent = await ctx.db
+  args: {},
+  handler: async (ctx) => {
+    const projects = await ctx.db
       .query("projects")
       .withIndex("by_status_hotScore", (q) => q.eq("status", "active"))
-      .order("desc")
       .collect();
-    return recent.filter((p) => p._creationTime >= args.periodStart).length;
+    return projects.length;
   },
 });
 

--- a/convex/emailRenderer.ts
+++ b/convex/emailRenderer.ts
@@ -957,12 +957,13 @@ export function renderFollowedProjectUpdateEmail(args: {
 
 export function renderCatalogInviteEmail(args: {
   recipientName: string;
+  recentResourceCount: number;
   baseUrl: string;
   profileUrl: string;
 }): RenderedEmail {
-  const { recipientName, baseUrl, profileUrl } = args;
-  const subject = "Help grow Honda's digital resource library";
-  const preheader = "See what your colleagues have built — and share what you've made.";
+  const { recipientName, recentResourceCount, baseUrl, profileUrl } = args;
+  const subject = "What your Honda colleagues have been building";
+  const preheader = `${recentResourceCount} ${recentResourceCount === 1 ? "resource was" : "resources were"} added to Garden this week.`;
   const submitUrl = joinUrl(baseUrl, "/submit");
   const homeUrl = joinUrl(baseUrl, "/");
 
@@ -984,7 +985,8 @@ export function renderCatalogInviteEmail(args: {
               <table width="100%" cellpadding="0" cellspacing="0" role="presentation" style="max-width: 640px; border-collapse: collapse; background-color: #ffffff; border-radius: 18px;">
                 <tr>
                   <td style="padding: 28px 28px 24px; border-bottom: 1px solid #e4e4e7;">
-                    <div style="font-size: 28px; font-weight: 700; color: #166534; margin: 0 0 16px;">Garden</div>
+                    <div style="font-size: 28px; font-weight: 700; color: #166534; margin: 0 0 8px;">Garden</div>
+                    <div style="font-size: 14px; color: #71717a; margin: 0 0 12px;">${escapeHtml(preheader)}</div>
                     <div style="font-size: 24px; font-weight: 700; line-height: 1.3; color: #18181b; margin: 0 0 10px;">Hi ${escapeHtml(recipientName)},</div>
                   </td>
                 </tr>
@@ -1010,9 +1012,13 @@ export function renderCatalogInviteEmail(args: {
                   </td>
                 </tr>
                 <tr>
-                  <td style="padding: 0 28px 28px;">
-                    <a href="${escapeHtml(submitUrl)}" style="display: inline-block; background-color: #166534; color: #ffffff; text-decoration: none; font-size: 14px; font-weight: 700; padding: 12px 18px; border-radius: 999px; margin-right: 10px;">Add a resource</a>
-                    <a href="${escapeHtml(homeUrl)}" style="display: inline-block; background-color: #ffffff; color: #166534; text-decoration: none; font-size: 14px; font-weight: 700; padding: 12px 18px; border-radius: 999px; border: 1.5px solid #166534;">Browse the library</a>
+                  <td style="padding: 0 28px 16px;">
+                    <a href="${escapeHtml(submitUrl)}" style="display: inline-block; background-color: #166534; color: #ffffff; text-decoration: none; font-size: 14px; font-weight: 700; padding: 12px 18px; border-radius: 999px;">Add a resource</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 0 28px 28px; font-size: 14px; color: #71717a;">
+                    or <a href="${escapeHtml(homeUrl)}" style="color: #166534; text-decoration: none;">browse the library</a>
                   </td>
                 </tr>
                 <tr>
@@ -1030,9 +1036,11 @@ export function renderCatalogInviteEmail(args: {
   `.trim();
 
   const text = [
-    `Garden — Help grow Honda's digital resource library`,
+    `Garden — What your Honda colleagues have been building`,
     "",
     `Hi ${recipientName},`,
+    "",
+    preheader,
     "",
     "A lot of people at Honda are quietly building useful things. Garden is where that work becomes visible.",
     "",

--- a/convex/emailRenderer.ts
+++ b/convex/emailRenderer.ts
@@ -963,7 +963,7 @@ export function renderCatalogInviteEmail(args: {
 }): RenderedEmail {
   const { recipientName, recentResourceCount, baseUrl, profileUrl } = args;
   const subject = "What your Honda colleagues have been building";
-  const preheader = `${recentResourceCount} ${recentResourceCount === 1 ? "resource was" : "resources were"} added to Garden this week.`;
+  const preheader = `Garden has ${recentResourceCount} ${recentResourceCount === 1 ? "resource" : "resources"} in the library.`;
   const submitUrl = joinUrl(baseUrl, "/submit");
   const homeUrl = joinUrl(baseUrl, "/");
 

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -154,6 +154,7 @@ export const sendEmail = internalAction({
     } else if (args.type === "catalog_invite") {
       const rendered = renderCatalogInviteEmail({
         recipientName: recipient.name,
+        recentResourceCount: (args.payload as { recentResourceCount: number }).recentResourceCount ?? 0,
         baseUrl,
         profileUrl,
       });


### PR DESCRIPTION
## Summary
This PR updates the catalog invite email template to display the current number of resources in the library and changes the digest generation schedule from Friday to Monday.

## Key Changes
- **Email Template Updates**
  - Added `recentResourceCount` parameter to `renderCatalogInviteEmail()`
  - Updated subject line from "Help grow Honda's digital resource library" to "What your Honda colleagues have been building"
  - Updated preheader to dynamically display resource count: "Garden has X resource(s) in the library"
  - Restructured CTA buttons: separated "Add a resource" and "Browse the library" into distinct rows with improved styling
  - Added preheader text to plain text email version

- **Digest Generation**
  - Created new `getRecentResourceCount` query to fetch active project count from the database
  - Modified `generateDigestBatch` to query and pass `recentResourceCount` to `enqueueCatalogInvite`
  - Updated `enqueueCatalogInvite` mutation to accept and store `recentResourceCount` in email payload
  - Updated `sendEmail` action to extract and pass `recentResourceCount` to email renderer

- **Schedule Change**
  - Changed weekly digest generation from Friday 12:00 PM EST (17:00 UTC) to Monday 11:00 AM EST (16:00 UTC)

## Implementation Details
- The resource count is queried once per digest batch and reused for all users in that batch for efficiency
- The count is stored in the email payload and passed through the email sending pipeline
- Email styling adjustments include reduced margins and improved visual hierarchy with the new preheader text

https://claude.ai/code/session_01LyZtmGubfmNnWtq5ZgR1do