### PR TITLE
Improve personalization scoring with base dampening and gravity adjustment

### DIFF
--- a/convex/projects/helpers.ts
+++ b/convex/projects/helpers.ts
@@ -2,7 +2,7 @@ import type { Id, Doc } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { getAllSpacesForProject } from "./spaces";
 
-const HOT_SCORE_GRAVITY = 1.0;
+const HOT_SCORE_GRAVITY = 1.8;
 const HOT_SCORE_AGE_OFFSET = 2;
 
 /**

--- a/convex/userAffinities.ts
+++ b/convex/userAffinities.ts
@@ -14,6 +14,10 @@ const ENGAGED_PENALTY = -0.3;
 const MAX_BOOST = 2.0;
 const MIN_BOOST = -0.3;
 
+// Dampen the base hot score so personalization boosts have more relative pull.
+// pow < 1 compresses the dynamic range while preserving order.
+const BASE_SCORE_EXPONENT = 0.5;
+
 // Recency decay: full weight within 7 days, linear decay to 0.3 over 90 days
 const FULL_WEIGHT_MS = 7 * 24 * 60 * 60 * 1000;
 const DECAY_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
@@ -240,9 +244,10 @@ async function scoreProjects(
     }
 
     const clampedBoost = clamp(boost, MIN_BOOST, MAX_BOOST);
+    const dampenedBase = Math.pow(Math.max(baseScore, 0), BASE_SCORE_EXPONENT);
     entries.push({
       projectId: project._id,
-      personalizedScore: baseScore * (1 + clampedBoost),
+      personalizedScore: dampenedBase * (1 + clampedBoost),
     });
   }
 
@@ -473,7 +478,11 @@ export const injectNewProjectIntoFeeds = internalMutation({
       }
 
       const clampedBoost = clamp(boost, MIN_BOOST, MAX_BOOST);
-      const personalizedScore = (project.hotScore ?? 0) * (1 + clampedBoost);
+      const dampenedBase = Math.pow(
+        Math.max(project.hotScore ?? 0, 0),
+        BASE_SCORE_EXPONENT
+      );
+      const personalizedScore = dampenedBase * (1 + clampedBoost);
 
       await ctx.db.insert("userFeedEntries", {
         userId: affinity.userId,


### PR DESCRIPTION
## Summary
This PR refines the project scoring algorithm to give personalization boosts more relative influence over base hotness scores, while also adjusting the gravity constant used in hot score calculations.

## Key Changes
- **Base score dampening**: Introduced `BASE_SCORE_EXPONENT` (0.5) to compress the dynamic range of base scores before applying personalization boosts. This is applied via `Math.pow(baseScore, 0.5)`, which preserves score ordering while reducing the dominance of high base scores.
- **Consistent dampening application**: Applied the dampening formula in two locations:
  - `scoreProjects()` function when calculating personalized scores
  - `injectNewProjectIntoFeeds()` mutation for new project feed injection
- **Increased hot score gravity**: Raised `HOT_SCORE_GRAVITY` from 1.0 to 1.8 in the hot score calculation helper, making the gravity component more influential in the base score computation.

## Implementation Details
- The dampening uses `Math.pow(Math.max(baseScore, 0), BASE_SCORE_EXPONENT)` to safely handle edge cases with non-positive scores
- The exponent value of 0.5 (square root) provides a moderate compression that allows personalization boosts to have more meaningful impact on final ranking
- Both scoring paths now use the same dampening logic for consistency

https://claude.ai/code/session_014JfVWMaSPuTzjNNDRf1rfw