### PR TITLE
Denormalize project engagement counts for performance

### DIFF
--- a/convex/comments.ts
+++ b/convex/comments.ts
@@ -29,9 +29,11 @@ export const addComment = mutation({
     if (project) {
       const now = Date.now();
       const newEngagementScore = (project.engagementScore ?? 0) + 1;
+      const newCommentCount = (project.commentCount ?? 0) + 1;
       const newHotScore = calculateHotScore(newEngagementScore, project._creationTime, now, project.lastVersionAt ?? undefined);
       await ctx.db.patch(args.projectId, {
         engagementScore: newEngagementScore,
+        commentCount: newCommentCount,
         hotScore: newHotScore,
       });
       await propagateHotScoreToMemberships(ctx, args.projectId, newHotScore);
@@ -160,9 +162,11 @@ export const deleteComment = mutation({
     if (project) {
       const now = Date.now();
       const newEngagementScore = Math.max(0, (project.engagementScore ?? 0) - 1);
+      const newCommentCount = Math.max(0, (project.commentCount ?? 0) - 1);
       const newHotScore = calculateHotScore(newEngagementScore, project._creationTime, now, project.lastVersionAt ?? undefined);
       await ctx.db.patch(comment.projectId, {
         engagementScore: newEngagementScore,
+        commentCount: newCommentCount,
         hotScore: newHotScore,
       });
       await propagateHotScoreToMemberships(ctx, comment.projectId, newHotScore);

--- a/convex/projects/engagement.ts
+++ b/convex/projects/engagement.ts
@@ -175,11 +175,8 @@ export const getUpvoteCount = query({
     projectId: v.id("projects"),
   },
   handler: async (ctx, args) => {
-    const upvotes = await ctx.db
-      .query("upvotes")
-      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
-      .collect();
-    return upvotes.length;
+    const project = await ctx.db.get(args.projectId);
+    return project?.upvoteCount ?? 0;
   },
 });
 

--- a/convex/projects/engagement.ts
+++ b/convex/projects/engagement.ts
@@ -58,9 +58,11 @@ export const toggleUpvote = mutation({
       await ctx.db.delete(existingUpvote._id);
       const now = Date.now();
       const newEngagementScore = Math.max(0, (project.engagementScore ?? 0) - 1);
+      const newUpvoteCount = Math.max(0, (project.upvoteCount ?? 0) - 1);
       const newHotScore = calculateHotScore(newEngagementScore, project._creationTime, now, project.lastVersionAt ?? undefined);
       await ctx.db.patch(args.projectId, {
         engagementScore: newEngagementScore,
+        upvoteCount: newUpvoteCount,
         hotScore: newHotScore,
       });
       await propagateHotScoreToMemberships(ctx, args.projectId, newHotScore);
@@ -82,9 +84,11 @@ export const toggleUpvote = mutation({
         createdAt: now,
       });
       const newEngagementScore = (project.engagementScore ?? 0) + 1;
+      const newUpvoteCount = (project.upvoteCount ?? 0) + 1;
       const newHotScore = calculateHotScore(newEngagementScore, project._creationTime, now, project.lastVersionAt ?? undefined);
       await ctx.db.patch(args.projectId, {
         engagementScore: newEngagementScore,
+        upvoteCount: newUpvoteCount,
         hotScore: newHotScore,
       });
       await propagateHotScoreToMemberships(ctx, args.projectId, newHotScore);
@@ -120,6 +124,9 @@ export const toggleFollow = mutation({
     }
     if (existingFollow) {
       await ctx.db.delete(existingFollow._id);
+      await ctx.db.patch(args.projectId, {
+        adoptionCount: Math.max(0, (project.adoptionCount ?? 0) - 1),
+      });
       await incrementalRemoveEngagedProject(ctx, user._id, args.projectId);
       return { followed: false };
     } else {
@@ -127,6 +134,9 @@ export const toggleFollow = mutation({
         projectId: args.projectId,
         userId: user._id,
         createdAt: Date.now(),
+      });
+      await ctx.db.patch(args.projectId, {
+        adoptionCount: (project.adoptionCount ?? 0) + 1,
       });
       if (project.userId !== user._id) {
         await emitNotificationEvent(ctx, {

--- a/convex/projects/helpers.ts
+++ b/convex/projects/helpers.ts
@@ -27,16 +27,7 @@ export async function enrichProjects(
 ) {
   return Promise.all(
     projects.map(async (project) => {
-      const [upvotes, comments, creator, team, mediaFiles, follows, spaces] = await Promise.all([
-        ctx.db
-          .query("upvotes")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .collect(),
-        ctx.db
-          .query("comments")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .filter((q) => q.neq(q.field("isDeleted"), true))
-          .collect(),
+      const [creator, team, mediaFiles, topFollows, spaces, hasUpvoted, hasFollowed] = await Promise.all([
         ctx.db.get(project.userId),
         project.teamId ? ctx.db.get(project.teamId) : Promise.resolve(null),
         ctx.db
@@ -48,8 +39,26 @@ export async function enrichProjects(
           .query("adoptions")
           .withIndex("by_project", (q) => q.eq("projectId", project._id))
           .order("desc")
-          .collect(),
+          .take(4),
         getAllSpacesForProject(ctx, project._id),
+        userId
+          ? ctx.db
+              .query("upvotes")
+              .withIndex("by_project_and_user", (q) =>
+                q.eq("projectId", project._id).eq("userId", userId)
+              )
+              .first()
+              .then((u) => u !== null)
+          : Promise.resolve(false),
+        userId
+          ? ctx.db
+              .query("adoptions")
+              .withIndex("by_project_and_user", (q) =>
+                q.eq("projectId", project._id).eq("userId", userId)
+              )
+              .first()
+              .then((a) => a !== null)
+          : Promise.resolve(false),
       ]);
 
       const previewMedia = await Promise.all(
@@ -62,7 +71,7 @@ export async function enrichProjects(
       );
 
       const followersWithInfo = await Promise.all(
-        follows.slice(0, 4).map(async (follow) => {
+        topFollows.map(async (follow) => {
           const user = await ctx.db.get(follow.userId);
           return {
             _id: follow.userId,
@@ -75,18 +84,18 @@ export async function enrichProjects(
       return {
         ...project,
         team: team?.name ?? "",
-        upvotes: upvotes.length,
+        upvotes: project.upvoteCount ?? 0,
         viewCount: project.viewCount ?? 0,
-        commentCount: comments.length,
-        hasUpvoted: userId ? upvotes.some((u) => u.userId === userId) : false,
+        commentCount: project.commentCount ?? 0,
+        hasUpvoted,
         creatorName: creator?.name ?? "Unknown User",
         creatorAvatar: creator?.avatarUrlId ?? "",
         focusArea: spaces.primary,
         additionalFocusAreas: spaces.secondary,
         previewMedia,
-        followerCount: follows.length,
+        followerCount: project.adoptionCount ?? 0,
         followers: followersWithInfo,
-        hasFollowed: userId ? follows.some((a) => a.userId === userId) : false,
+        hasFollowed,
       };
     })
   );

--- a/convex/projects/migrations.ts
+++ b/convex/projects/migrations.ts
@@ -58,6 +58,38 @@ export const reindexProjectInRag = internalAction({
   },
 });
 
+export const backfillProjectCounts = internalMutationFromFunctions({
+  args: {},
+  handler: async (ctx) => {
+    const projects = await ctx.db.query("projects").collect();
+    let updated = 0;
+    for (const project of projects) {
+      const [upvotes, comments, adoptions] = await Promise.all([
+        ctx.db
+          .query("upvotes")
+          .withIndex("by_project", (q) => q.eq("projectId", project._id))
+          .collect(),
+        ctx.db
+          .query("comments")
+          .withIndex("by_project", (q) => q.eq("projectId", project._id))
+          .filter((q) => q.neq(q.field("isDeleted"), true))
+          .collect(),
+        ctx.db
+          .query("adoptions")
+          .withIndex("by_project", (q) => q.eq("projectId", project._id))
+          .collect(),
+      ]);
+      await ctx.db.patch(project._id, {
+        upvoteCount: upvotes.length,
+        commentCount: comments.length,
+        adoptionCount: adoptions.length,
+      });
+      updated++;
+    }
+    return { updated };
+  },
+});
+
 export const reindexAllProjectsInRag = internalAction({
   args: {},
   handler: async (ctx) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -24,6 +24,9 @@ export default defineSchema({
     hotScore: v.optional(v.number()),
     versionCount: v.optional(v.number()),
     lastVersionAt: v.optional(v.number()),
+    upvoteCount: v.optional(v.number()),
+    commentCount: v.optional(v.number()),
+    adoptionCount: v.optional(v.number()),
   })
     .searchIndex("allFields", { searchField: "allFields" })
     .index("by_entryId", ["entryId"])


### PR DESCRIPTION
## Summary
This PR optimizes project enrichment performance by denormalizing engagement counts (upvotes, comments, adoptions) directly onto the project document, eliminating the need to query and count related records on every enrichment.

## Key Changes

- **Schema updates**: Added `upvoteCount`, `commentCount`, and `adoptionCount` fields to the projects table
- **Engagement tracking**: Updated `toggleUpvote()` and `toggleFollow()` mutations to maintain denormalized counts when upvotes/adoptions are added or removed
- **Comment tracking**: Updated `addComment()` and `deleteComment()` mutations to maintain denormalized comment counts
- **Optimized enrichment**: Refactored `enrichProjects()` to:
  - Read counts from project document instead of querying related tables
  - Limit follows query to top 4 results using `.take(4)` instead of fetching all and slicing
  - Use indexed queries for user-specific upvote/follow checks (`by_project_and_user` indexes)
  - Reduce parallel queries from 7 to 7 (same count but more efficient)
- **Migration**: Added `backfillProjectCounts()` migration to populate denormalized counts for existing projects

## Implementation Details

- Denormalized counts are maintained transactionally alongside engagement score and hot score updates
- User-specific engagement checks now use dedicated indexes for O(1) lookups instead of filtering full result sets
- The migration allows safe rollout without data loss or inconsistency
- Follows/adoptions are now limited to top 4 at the database level rather than in application code

https://claude.ai/code/session_01QFqkZn869tZAJaUrdTvPBU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Project engagement metrics (upvotes, comments, followers) now use dedicated tracking counters for improved accuracy and real-time consistency
  * Enhanced platform performance with faster engagement metric calculations and display updates
  * Engagement statistics now reliably reflect user interactions with improved tracking reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->