### PR TITLE
Optimize project listing query with denormalized counts

### DIFF
--- a/convex/projects/listing.ts
+++ b/convex/projects/listing.ts
@@ -389,58 +389,66 @@ export const getById = query({
     if (!project) {
       return null;
     }
-    const upvotes = await ctx.db
-      .query("upvotes")
-      .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
-      .collect();
-    const follows = await ctx.db
+    const currentUser = await getCurrentUser(ctx);
+    const userUpvotePromise = currentUser
+      ? ctx.db
+          .query("upvotes")
+          .withIndex("by_project_and_user", (q) =>
+            q.eq("projectId", args.projectId).eq("userId", currentUser._id)
+          )
+          .first()
+      : Promise.resolve(null);
+    const userAdoptionPromise = currentUser
+      ? ctx.db
+          .query("adoptions")
+          .withIndex("by_project_and_user", (q) =>
+            q.eq("projectId", args.projectId).eq("userId", currentUser._id)
+          )
+          .first()
+      : Promise.resolve(null);
+    const recentFollowsPromise = ctx.db
       .query("adoptions")
       .withIndex("by_project", (q) => q.eq("projectId", args.projectId))
       .order("desc")
-      .collect();
-    const currentUser = await getCurrentUser(ctx);
-    let hasUpvoted = false;
-    let hasFollowed = false;
-    if (currentUser) {
-      const userUpvote = await ctx.db
-        .query("upvotes")
-        .withIndex("by_project_and_user", (q) =>
-          q.eq("projectId", args.projectId).eq("userId", currentUser._id)
-        )
-        .first();
-      hasUpvoted = !!userUpvote;
-      hasFollowed = follows.some((a) => a.userId === currentUser._id);
-    }
-    const creator = await ctx.db.get(project.userId);
-    let teamName = "";
-    if (project.teamId) {
-      const team = await ctx.db.get(project.teamId);
-      teamName = team?.name ?? "";
-    }
-    const [followersWithInfo, spaces] = await Promise.all([
-      Promise.all(
-        follows.slice(0, 6).map(async (follow) => {
-          const user = await ctx.db.get(follow.userId);
-          return {
-            _id: follow.userId,
-            name: user?.name ?? "Unknown User",
-            avatarUrl: user?.avatarUrlId ?? "",
-          };
-        })
-      ),
-      getAllSpacesForProject(ctx, args.projectId),
-    ]);
+      .take(6);
+    const creatorPromise = ctx.db.get(project.userId);
+    const teamPromise = project.teamId
+      ? ctx.db.get(project.teamId)
+      : Promise.resolve(null);
+    const spacesPromise = getAllSpacesForProject(ctx, args.projectId);
+    const [userUpvote, userAdoption, recentFollows, creator, team, spaces] =
+      await Promise.all([
+        userUpvotePromise,
+        userAdoptionPromise,
+        recentFollowsPromise,
+        creatorPromise,
+        teamPromise,
+        spacesPromise,
+      ]);
+    const hasUpvoted = !!userUpvote;
+    const hasFollowed = !!userAdoption;
+    const teamName = team?.name ?? "";
+    const followersWithInfo = await Promise.all(
+      recentFollows.map(async (follow) => {
+        const user = await ctx.db.get(follow.userId);
+        return {
+          _id: follow.userId,
+          name: user?.name ?? "Unknown User",
+          avatarUrl: user?.avatarUrlId ?? "",
+        };
+      })
+    );
     return {
       ...project,
       team: teamName,
-      upvotes: upvotes.length,
+      upvotes: project.upvoteCount ?? 0,
       viewCount: project.viewCount ?? 0,
       hasUpvoted,
       creatorName: creator?.name ?? "Unknown User",
       creatorAvatar: creator?.avatarUrlId ?? "",
       focusArea: spaces.primary,
       additionalFocusAreas: spaces.secondary,
-      followerCount: follows.length,
+      followerCount: project.adoptionCount ?? 0,
       followers: followersWithInfo,
       hasFollowed,
     };


### PR DESCRIPTION
## Summary
Refactored the `getById` query in the project listing module to improve performance by using denormalized count fields and optimizing database queries through parallel execution.

## Key Changes
- **Replaced collection counts with denormalized fields**: Changed from counting all upvotes and adoptions to using `project.upvoteCount` and `project.adoptionCount` fields, eliminating expensive collection operations
- **Optimized user state queries**: Changed from querying all upvotes/adoptions to only fetching the current user's specific records using indexed queries
- **Parallelized database operations**: Restructured sequential queries into a single `Promise.all()` call to fetch user upvote, user adoption, recent follows, creator, team, and spaces concurrently
- **Simplified adoption lookup**: Changed from filtering follows array to using a dedicated `by_project_and_user` index on adoptions table for direct lookup
- **Limited recent followers**: Changed from fetching all adoptions to using `.take(6)` to only retrieve the 6 most recent followers

## Implementation Details
- The refactoring maintains the same API response structure while reducing database load
- User-specific queries now use indexed lookups (`by_project_and_user`) instead of full collection scans
- Recent followers are now fetched in a single query with a limit, rather than fetching all and slicing in memory
- All database operations are now executed in parallel, improving query latency

https://claude.ai/code/session_01AxijWqXPfeiHP2BnHGcNft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized project details page performance by refining how upvote information and adoption data are retrieved. Instead of loading complete historical records, the system now efficiently fetches only recent adoption entries and upvote status as needed, resulting in faster page load times and improved overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->