### PR TITLE
Optimize enrichProjects with batch deduplication

### DIFF
--- a/convex/projects/helpers.ts
+++ b/convex/projects/helpers.ts
@@ -1,6 +1,5 @@
 import type { Id, Doc } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
-import { getAllSpacesForProject } from "./spaces";
 
 const HOT_SCORE_GRAVITY = 1.8;
 const HOT_SCORE_AGE_OFFSET = 2;
@@ -25,78 +24,150 @@ export async function enrichProjects(
   projects: Doc<"projects">[],
   userId: Id<"users"> | undefined
 ) {
-  return Promise.all(
+  // Phase 1: per-project queries (can't be deduped across projects)
+  const perProject = await Promise.all(
     projects.map(async (project) => {
-      const [creator, team, mediaFiles, topFollows, spaces, hasUpvoted, hasFollowed] = await Promise.all([
-        ctx.db.get(project.userId),
-        project.teamId ? ctx.db.get(project.teamId) : Promise.resolve(null),
-        ctx.db
-          .query("mediaFiles")
-          .withIndex("by_project_ordered", (q) => q.eq("projectId", project._id))
-          .order("asc")
-          .collect(),
-        ctx.db
-          .query("adoptions")
-          .withIndex("by_project", (q) => q.eq("projectId", project._id))
-          .order("desc")
-          .take(4),
-        getAllSpacesForProject(ctx, project._id),
-        userId
-          ? ctx.db
-              .query("upvotes")
-              .withIndex("by_project_and_user", (q) =>
-                q.eq("projectId", project._id).eq("userId", userId)
-              )
-              .first()
-              .then((u) => u !== null)
-          : Promise.resolve(false),
-        userId
-          ? ctx.db
-              .query("adoptions")
-              .withIndex("by_project_and_user", (q) =>
-                q.eq("projectId", project._id).eq("userId", userId)
-              )
-              .first()
-              .then((a) => a !== null)
-          : Promise.resolve(false),
-      ]);
+      const [mediaFiles, topFollows, projectSpaceRows, hasUpvoted, hasFollowed] =
+        await Promise.all([
+          ctx.db
+            .query("mediaFiles")
+            .withIndex("by_project_ordered", (q) => q.eq("projectId", project._id))
+            .order("asc")
+            .collect(),
+          ctx.db
+            .query("adoptions")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .order("desc")
+            .take(4),
+          ctx.db
+            .query("projectSpaces")
+            .withIndex("by_project", (q) => q.eq("projectId", project._id))
+            .collect(),
+          userId
+            ? ctx.db
+                .query("upvotes")
+                .withIndex("by_project_and_user", (q) =>
+                  q.eq("projectId", project._id).eq("userId", userId)
+                )
+                .first()
+                .then((u) => u !== null)
+            : Promise.resolve(false),
+          userId
+            ? ctx.db
+                .query("adoptions")
+                .withIndex("by_project_and_user", (q) =>
+                  q.eq("projectId", project._id).eq("userId", userId)
+                )
+                .first()
+                .then((a) => a !== null)
+            : Promise.resolve(false),
+        ]);
+      return {
+        project,
+        mediaFiles,
+        topFollows,
+        projectSpaceRows,
+        hasUpvoted,
+        hasFollowed,
+      };
+    })
+  );
 
-      const previewMedia = await Promise.all(
-        mediaFiles.map(async (media) => ({
-          _id: media._id,
-          storageId: media.storageId,
-          type: media.type,
-          url: await ctx.storage.getUrl(media.storageId),
-        }))
-      );
+  // Phase 2: batch-fetch unique users, focus areas, teams
+  const userIdSet = new Set<Id<"users">>();
+  const focusAreaIdSet = new Set<Id<"focusAreas">>();
+  const teamIdSet = new Set<Id<"teams">>();
+  for (const item of perProject) {
+    userIdSet.add(item.project.userId);
+    for (const f of item.topFollows) userIdSet.add(f.userId);
+    for (const r of item.projectSpaceRows) focusAreaIdSet.add(r.focusAreaId);
+    if (item.project.teamId) teamIdSet.add(item.project.teamId);
+  }
 
-      const followersWithInfo = await Promise.all(
-        topFollows.map(async (follow) => {
-          const user = await ctx.db.get(follow.userId);
+  const [userEntries, focusAreaEntries, teamEntries] = await Promise.all([
+    Promise.all(
+      Array.from(userIdSet).map(
+        async (id) => [id, await ctx.db.get(id)] as const
+      )
+    ),
+    Promise.all(
+      Array.from(focusAreaIdSet).map(
+        async (id) => [id, await ctx.db.get(id)] as const
+      )
+    ),
+    Promise.all(
+      Array.from(teamIdSet).map(
+        async (id) => [id, await ctx.db.get(id)] as const
+      )
+    ),
+  ]);
+  const userMap = new Map(userEntries);
+  const focusAreaMap = new Map(focusAreaEntries);
+  const teamMap = new Map(teamEntries);
+
+  // Phase 3: assemble + resolve media URLs in parallel
+  return Promise.all(
+    perProject.map(
+      async ({
+        project,
+        mediaFiles,
+        topFollows,
+        projectSpaceRows,
+        hasUpvoted,
+        hasFollowed,
+      }) => {
+        const creator = userMap.get(project.userId) ?? null;
+        const team = project.teamId ? teamMap.get(project.teamId) ?? null : null;
+
+        const validSpaces = projectSpaceRows
+          .map((row) => {
+            const fa = focusAreaMap.get(row.focusAreaId);
+            if (!fa || !fa.isActive) return null;
+            return {
+              isPrimary: row.isPrimary,
+              space: { _id: fa._id, name: fa.name, group: fa.group, icon: fa.icon },
+            };
+          })
+          .filter((r): r is NonNullable<typeof r> => r !== null);
+
+        const primary = validSpaces.find((r) => r.isPrimary)?.space ?? null;
+        const secondary = validSpaces.filter((r) => !r.isPrimary).map((r) => r.space);
+
+        const previewMedia = await Promise.all(
+          mediaFiles.map(async (media) => ({
+            _id: media._id,
+            storageId: media.storageId,
+            type: media.type,
+            url: await ctx.storage.getUrl(media.storageId),
+          }))
+        );
+
+        const followersWithInfo = topFollows.map((follow) => {
+          const user = userMap.get(follow.userId);
           return {
             _id: follow.userId,
             name: user?.name ?? "Unknown User",
             avatarUrl: user?.avatarUrlId ?? "",
           };
-        })
-      );
+        });
 
-      return {
-        ...project,
-        team: team?.name ?? "",
-        upvotes: project.upvoteCount ?? 0,
-        viewCount: project.viewCount ?? 0,
-        commentCount: project.commentCount ?? 0,
-        hasUpvoted,
-        creatorName: creator?.name ?? "Unknown User",
-        creatorAvatar: creator?.avatarUrlId ?? "",
-        focusArea: spaces.primary,
-        additionalFocusAreas: spaces.secondary,
-        previewMedia,
-        followerCount: project.adoptionCount ?? 0,
-        followers: followersWithInfo,
-        hasFollowed,
-      };
-    })
+        return {
+          ...project,
+          team: team?.name ?? "",
+          upvotes: project.upvoteCount ?? 0,
+          viewCount: project.viewCount ?? 0,
+          commentCount: project.commentCount ?? 0,
+          hasUpvoted,
+          creatorName: creator?.name ?? "Unknown User",
+          creatorAvatar: creator?.avatarUrlId ?? "",
+          focusArea: primary,
+          additionalFocusAreas: secondary,
+          previewMedia,
+          followerCount: project.adoptionCount ?? 0,
+          followers: followersWithInfo,
+          hasFollowed,
+        };
+      }
+    )
   );
 }

--- a/convex/projects/personalizedFeed.ts
+++ b/convex/projects/personalizedFeed.ts
@@ -12,20 +12,7 @@ export const listPersonalizedFeed = query({
 
     if (!currentUser) {
       // Anonymous users: fall back to global hotScore feed
-      return fallbackToGlobalFeed(ctx, args);
-    }
-
-    // Check if user has feed entries
-    const hasEntries = await ctx.db
-      .query("userFeedEntries")
-      .withIndex("by_userId_personalizedScore", (q) =>
-        q.eq("userId", currentUser._id)
-      )
-      .first();
-
-    if (!hasEntries) {
-      // No precomputed feed yet — fall back to global feed
-      return fallbackToGlobalFeed(ctx, args);
+      return fallbackToGlobalFeed(ctx, args, undefined);
     }
 
     // Native Convex cursor-based pagination on precomputed scores
@@ -36,6 +23,14 @@ export const listPersonalizedFeed = query({
       )
       .order("desc")
       .paginate(args.paginationOpts);
+
+    // If first page is empty, no precomputed feed exists yet — fall back.
+    if (
+      paginatedResult.page.length === 0 &&
+      !args.paginationOpts.cursor
+    ) {
+      return fallbackToGlobalFeed(ctx, args, currentUser._id);
+    }
 
     // Resolve project docs, filter inactive
     const resolvedProjects = (
@@ -57,11 +52,9 @@ export const listPersonalizedFeed = query({
 
 async function fallbackToGlobalFeed(
   ctx: QueryCtx,
-  args: { paginationOpts: { numItems: number; cursor: string | null } }
+  args: { paginationOpts: { numItems: number; cursor: string | null } },
+  userId: Doc<"users">["_id"] | undefined
 ) {
-  const currentUser = await getCurrentUser(ctx);
-  const userId = currentUser?._id;
-
   const paginatedResult = await ctx.db
     .query("projects")
     .withIndex("by_status_hotScore", (q) => q.eq("status", "active"))


### PR DESCRIPTION
## Summary
Refactored `enrichProjects` to deduplicate database queries across multiple projects, reducing N+1 query patterns. Instead of fetching users, focus areas, and teams individually per project, we now collect unique IDs across all projects and batch-fetch them once.

## Key Changes

- **Removed dependency**: Deleted import of `getAllSpacesForProject` from `convex/projects/spaces.ts`
- **Three-phase enrichment pipeline**:
  1. **Phase 1**: Per-project queries (mediaFiles, adoptions, projectSpaces, upvotes, adoptions) — cannot be deduped
  2. **Phase 2**: Batch-fetch unique users, focus areas, and teams across all projects using `Set` deduplication
  3. **Phase 3**: Assemble enriched results and resolve media URLs in parallel
- **Direct projectSpaces query**: Replaced `getAllSpacesForProject()` call with direct `ctx.db.query("projectSpaces")` to avoid function call overhead
- **Inline space resolution**: Moved space validation and filtering logic inline, filtering by `isActive` status and mapping to simplified space objects
- **Removed async overhead**: Changed `followersWithInfo` from `Promise.all()` to synchronous map using pre-fetched user data

## Implementation Details

- Uses `Map` for O(1) lookups of users, focus areas, and teams during Phase 3
- Filters out inactive focus areas during space assembly
- Maintains backward compatibility with the same return type and behavior
- Reduces database round-trips from O(n) to O(1) for shared entities (users, teams, focus areas)

## Related Changes
Updated `convex/projects/personalizedFeed.ts` to pass `userId` parameter to `fallbackToGlobalFeed()` and check for empty first page before falling back, improving feed initialization logic.

https://claude.ai/code/session_01SnSjVJDG4evmRbXyW8KTG1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty personalized feed by falling back to global feed when needed.
  * Improved handling of feeds for anonymous users.

* **Performance**
  * Optimized project information loading for improved responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan0902/project-hunt/pull/191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->