### PR TITLE
Improve ReadinessBadge layout with flexbox alignment

### DIFF
--- a/app/(app)/project/[id]/page.tsx
+++ b/app/(app)/project/[id]/page.tsx
@@ -313,12 +313,11 @@ export default function ProjectPage({
                     <Pencil className="h-4 w-4" />
                   </Button>
                 )}
-                <div>
-                  <h1 className="inline text-2xl font-semibold text-zinc-900">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h1 className="text-2xl font-semibold text-zinc-900">
                     {project.name}
                   </h1>
-                  {" "}
-                  <ReadinessBadge status={project.readinessStatus} className="align-middle" />
+                  <ReadinessBadge status={project.readinessStatus} />
                 </div>
               </div>
               {projectMedia && projectMedia.length > 0 && (

--- a/components/ProjectRow.tsx
+++ b/components/ProjectRow.tsx
@@ -97,10 +97,9 @@ export function ProjectRow({
       </div>
 
       {/* Title */}
-      <div className="-mt-1">
-        <h3 className="inline text-lg font-semibold text-zinc-900">{project.name}</h3>
-        {" "}
-        <ReadinessBadge status={project.readinessStatus} className="align-middle" />
+      <div className="-mt-1 flex flex-wrap items-center gap-2">
+        <h3 className="text-lg font-semibold text-zinc-900">{project.name}</h3>
+        <ReadinessBadge status={project.readinessStatus} />
       </div>
 
       {/* Media carousel OR summary - not both */}


### PR DESCRIPTION
## Summary
Refactored the layout of project titles and readiness badges to use flexbox for better alignment and spacing, removing manual inline styling and text node spacing.

## Changes
- **ProjectPage detail view** (`app/(app)/project/[id]/page.tsx`):
  - Changed title container from `<div>` to `<div className="flex flex-wrap items-center gap-2">` for proper flexbox alignment
  - Removed `inline` class from `<h1>` to work with flexbox layout
  - Removed manual text node spacing (`{" "}`) between title and badge
  - Removed `align-middle` class from `ReadinessBadge` (no longer needed with flexbox)

- **ProjectRow list item** (`components/ProjectRow.tsx`):
  - Applied same flexbox layout pattern to title container
  - Changed from inline layout to `flex flex-wrap items-center gap-2`
  - Removed `inline` class from `<h3>` 
  - Removed manual text node spacing between title and badge
  - Removed `align-middle` class from `ReadinessBadge`

## Implementation Details
The changes replace manual inline alignment with Tailwind's flexbox utilities:
- `flex flex-wrap` allows wrapping on smaller screens
- `items-center` vertically centers the badge with the title
- `gap-2` provides consistent spacing between elements

This approach is more maintainable and responsive than relying on `inline` display and manual spacing nodes.

https://claude.ai/code/session_01QgrFsxZmYe71xD392R3DFa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual layout and spacing of project titles and readiness badges for better readability and consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan0902/project-hunt/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->