### PR TITLE
Fix readiness badge vertical alignment without breaking inline flow

### DIFF
--- a/app/(app)/project/[id]/page.tsx
+++ b/app/(app)/project/[id]/page.tsx
@@ -313,11 +313,12 @@ export default function ProjectPage({
                     <Pencil className="h-4 w-4" />
                   </Button>
                 )}
-                <div className="flex flex-wrap items-center gap-2">
-                  <h1 className="text-2xl font-semibold text-zinc-900">
+                <div>
+                  <h1 className="inline text-2xl font-semibold text-zinc-900">
                     {project.name}
                   </h1>
-                  <ReadinessBadge status={project.readinessStatus} />
+                  {" "}
+                  <ReadinessBadge status={project.readinessStatus} className="relative -top-0.5 align-middle" />
                 </div>
               </div>
               {projectMedia && projectMedia.length > 0 && (

--- a/components/ProjectRow.tsx
+++ b/components/ProjectRow.tsx
@@ -97,9 +97,10 @@ export function ProjectRow({
       </div>
 
       {/* Title */}
-      <div className="-mt-1 flex flex-wrap items-center gap-2">
-        <h3 className="text-lg font-semibold text-zinc-900">{project.name}</h3>
-        <ReadinessBadge status={project.readinessStatus} />
+      <div className="-mt-1">
+        <h3 className="inline text-lg font-semibold text-zinc-900">{project.name}</h3>
+        {" "}
+        <ReadinessBadge status={project.readinessStatus} className="relative -top-0.5 align-middle" />
       </div>
 
       {/* Media carousel OR summary - not both */}


### PR DESCRIPTION
Reverts the flex layout (which caused the badge to always appear on a new row when the title wraps) and instead keeps heading as inline with the badge trailing the last word. Adds relative -top-0.5 to nudge the badge up ~2px, correcting align-middle anchoring to x-height rather than the cap-height of the larger heading text.

https://claude.ai/code/session_01QgrFsxZmYe71xD392R3DFa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the alignment and spacing of project titles with readiness badges for improved visual consistency across project views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan0902/project-hunt/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->